### PR TITLE
Install Type Selection Stage

### DIFF
--- a/src/actions/InstallActions.ts
+++ b/src/actions/InstallActions.ts
@@ -37,7 +37,7 @@ export class InstallActions {
 
   runInstallation (
     connectionArgs: IIpcConnectionArgs, 
-    installationArgs: {installationDir: string}, 
+    installationArgs: {installationDir: string, installationType: string, userUploadedPaxPath: string},
     version: string): Promise<IResponse> {
     return this.strategy.runInstallation(connectionArgs, installationArgs, version);
   }

--- a/src/actions/InstallationHandler.ts
+++ b/src/actions/InstallationHandler.ts
@@ -21,7 +21,7 @@ class Installation {
 
   public async runInstallation (
     connectionArgs: IIpcConnectionArgs, 
-    installationArgs: {installationDir: string, installationType: string},
+    installationArgs: {installationDir: string, installationType: string, userUploadedPaxPath: string},
     version: string
   ): Promise<IResponse> {
 
@@ -43,7 +43,13 @@ class Installation {
       }
 
       console.log("uploading...");
-      const upload = await this.uploadPax(connectionArgs, installationArgs.installationDir);
+      let upload;
+      if(installationArgs.installationType === "upload"){
+        //upload the PAX the user selected in the "Install Type" stage to the installation dir (from the planning stage)
+        upload = await new FileTransfer().upload(connectionArgs, installationArgs.userUploadedPaxPath, path.join(installationArgs.installationDir, "zowe.pax"), DataType.BINARY)
+      } else if (installationArgs.installationType === "download"){
+        upload = await this.uploadPax(connectionArgs, installationArgs.installationDir);
+      }
       ProgressStore.set('installation.upload', upload.status);
 
       console.log("unpaxing...");

--- a/src/actions/InstallationHandler.ts
+++ b/src/actions/InstallationHandler.ts
@@ -21,7 +21,7 @@ class Installation {
 
   public async runInstallation (
     connectionArgs: IIpcConnectionArgs, 
-    installationArgs: {installationDir: string}, 
+    installationArgs: {installationDir: string, installationType: string},
     version: string
   ): Promise<IResponse> {
 
@@ -35,9 +35,12 @@ class Installation {
       const uploadYaml = await this.uploadYaml(connectionArgs, installationArgs.installationDir);
       ProgressStore.set('installation.uploadYaml', uploadYaml.status);
 
-      console.log("downloading...", version);
-      const download = await this.downloadPax(version);
-      ProgressStore.set('installation.download', download.status);
+      let download;
+      if(installationArgs.installationType === "download"){
+        console.log("downloading...", version);
+        download = await this.downloadPax(version);
+        ProgressStore.set('installation.download', download.status);
+      }
 
       console.log("uploading...");
       const upload = await this.uploadPax(connectionArgs, installationArgs.installationDir);
@@ -51,7 +54,7 @@ class Installation {
       const install = await this.install(connectionArgs, installationArgs.installationDir);
       ProgressStore.set('installation.install', install.status);
 
-      return {status: download.status && uploadYaml.status && upload.status && unpax.status && install.status, details: ''};
+      return {status: (installationArgs.installationType === "download" && download.status) && uploadYaml.status && upload.status && unpax.status && install.status, details: ''};
     } catch (error) {
       return {status: false, details: error.message};
     }

--- a/src/actions/InstallationHandler.ts
+++ b/src/actions/InstallationHandler.ts
@@ -40,14 +40,18 @@ class Installation {
         console.log("downloading...", version);
         download = await this.downloadPax(version);
         ProgressStore.set('installation.download', download.status);
+      } else {
+        ProgressStore.set('installation.download', true);
       }
 
       console.log("uploading...");
       let upload;
       if(installationArgs.installationType === "upload"){
         //upload the PAX the user selected in the "Install Type" stage to the installation dir (from the planning stage)
+        console.log('Uploading user selected pax')
         upload = await new FileTransfer().upload(connectionArgs, installationArgs.userUploadedPaxPath, path.join(installationArgs.installationDir, "zowe.pax"), DataType.BINARY)
       } else if (installationArgs.installationType === "download"){
+        console.log('Uploading pax downloaded from jfrog')
         upload = await this.uploadPax(connectionArgs, installationArgs.installationDir);
       }
       ProgressStore.set('installation.upload', upload.status);
@@ -128,6 +132,7 @@ export class FTPInstallation extends Installation {
   async uploadPax(connectionArgs: IIpcConnectionArgs, installDir: string): Promise<IResponse> {
     const tempPath = path.join(app.getPath("temp"), "zowe.pax");
     const filePath = path.join(installDir, "zowe.pax");
+    console.log(`Uploading ${tempPath} to ${filePath}`)
     const result = await new FileTransfer().upload(connectionArgs, tempPath, filePath, DataType.BINARY);
     const fs = require('fs');
     try {

--- a/src/actions/InstallationHandler.ts
+++ b/src/actions/InstallationHandler.ts
@@ -64,7 +64,7 @@ class Installation {
       const install = await this.install(connectionArgs, installationArgs.installationDir);
       ProgressStore.set('installation.install', install.status);
 
-      return {status: (installationArgs.installationType === "download" && download.status) && uploadYaml.status && upload.status && unpax.status && install.status, details: ''};
+      return {status: download.status && uploadYaml.status && upload.status && unpax.status && install.status, details: ''};
     } catch (error) {
       return {status: false, details: error.message};
     }

--- a/src/actions/InstallationHandler.ts
+++ b/src/actions/InstallationHandler.ts
@@ -41,6 +41,7 @@ class Installation {
         download = await this.downloadPax(version);
         ProgressStore.set('installation.download', download.status);
       } else {
+        download = {status: true}
         ProgressStore.set('installation.download', true);
       }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -16,6 +16,7 @@ import { InstallActions } from "../actions/InstallActions";
 import { PlanningActions } from "../actions/PlanningActions";
 import { IIpcConnectionArgs, IResponse } from '../types/interfaces';
 import { ProgressStore } from "../storage/ProgressStore";
+import { checkDirExists } from '../services/utils';
 
 declare const MAIN_WINDOW_WEBPACK_ENTRY: string;
 declare const MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY: string;
@@ -118,6 +119,11 @@ const createWindow = (): void => {
     const res: any = await PlanningActions.checkSpace(connectionArgs, location);
     return res;
   });
+
+  ipcMain.handle('check-dir-exists', async (event, connectionArgs, location) => {
+    const res: any = await checkDirExists(connectionArgs, location);
+    return res;
+  })
 
   ipcMain.handle('install-mvs', async (event, connectionArgs, installationArgs, version) => {
     const res = await installActions.runInstallation(connectionArgs, installationArgs, version);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,7 +8,7 @@
  * Copyright Contributors to the Zowe Project.
  */
 
-import { app, BrowserWindow, ipcMain } from 'electron';
+import { app, BrowserWindow, dialog, ipcMain } from 'electron';
 import MenuBuilder from './menu';
 import { HomeActions } from "../actions/HomeActions";
 import { ConnectionActions } from "../actions/ConnectionActions";
@@ -56,6 +56,12 @@ const createWindow = (): void => {
   ipcMain.handle('get-installation-history', (event) => {
     const res: IResponse = HomeActions.findPreviousInstallations();
     return res;
+  });
+
+  ipcMain.handle('upload-pax', async (event) => {
+    return await dialog.showOpenDialog({ properties: ['openFile'], filters: [
+      { name: 'pax', extensions: ['pax'] },
+    ] });
   });
 
   ipcMain.handle('save-job-header', async (event, jobStatement) => {

--- a/src/renderer/components/configuration-wizard/Wizard.tsx
+++ b/src/renderer/components/configuration-wizard/Wizard.tsx
@@ -16,15 +16,17 @@ import Configuration from "../stages/Configuration";
 import Certificates from "../stages/Certificates";
 import Initialization from "../stages/Initialization";
 import spock from '../../assets/spock.svg'
+import InstallationType from '../stages/installation/InstallTypeSelection';
 import { selectLoading } from './wizardSlice';
 import { useAppSelector } from '../../hooks';
 
 const stages = [
   {id: 0, label: 'Connection', component: <Connection/>, nextButton: 'Continue'},
-  {id: 1, label: 'Planning', component: <Planning/>, nextButton: 'Continue to components installation'},
-  {id: 2, label: 'Installation', component: <Installation/>, nextButton: 'Continue to system configuration'},
-  {id: 3, label: 'Configuration', component: <Configuration/>, nextButton: 'Continue to certificates setup'},
-  {id: 4, label: 'Certificates', component: <Certificates/>, nextButton: 'Continue to instance setup'},
+  {id: 1, label: 'Planning', component: <Planning/>, nextButton: 'Continue to installation options'},
+  {id: 2, label: 'Installation Type', component: <InstallationType/>, nextButton: 'Continue to components installation'},
+  {id: 3, label: 'Installation', component: <Installation/>, nextButton: 'Continue to system configuration'},
+  {id: 4, label: 'Configuration', component: <Configuration/>, nextButton: 'Continue to certificates setup'},
+  {id: 5, label: 'Certificates', component: <Certificates/>, nextButton: 'Continue to instance setup'},
   {id: 6, label: 'Initialization', component: <Initialization/>, nextButton: <div style={{display: 'flex', alignItems: 'center'}}><img style={{width: '18px', height: '18px', paddingRight: '12px'}} src={spock}/>Live long and prosper</div>},
 ]
 

--- a/src/renderer/components/stages/installation/InstallTypeSelection.tsx
+++ b/src/renderer/components/stages/installation/InstallTypeSelection.tsx
@@ -17,7 +17,8 @@ import { selectInstallationArgs, selectZoweVersion, setInstallationArgs } from '
 import { selectConnectionArgs } from '../connection/connectionSlice';
 import JsonForm from '../../common/JsonForms';
 import { IResponse } from '../../../../types/interfaces';
-import ProgressCard from '../../common/ProgressCard'
+import ProgressCard from '../../common/ProgressCard';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 
 const InstallationType = () => {
 
@@ -32,6 +33,7 @@ const InstallationType = () => {
   const [installValue, setInstallValue] = useState("download");
   const [paxPath, setPaxPath] = useState("");
   const [smpePath, setSmpePath] = useState("");
+  const [smpePathValidated, setSmpePathValidated] = useState(false);
 
   const installationArgs = useAppSelector(selectInstallationArgs);
   const version = useAppSelector(selectZoweVersion);
@@ -81,8 +83,20 @@ const InstallationType = () => {
             variant="standard"
             helperText="Location of Zowe SMPE installation."
             value={installationArgs.smpeDir}
-            onChange={(e) => dispatch(setInstallationArgs({...installationArgs, smpeDir: e.target.value}))}
+            onChange={(e) => {
+                dispatch(setInstallationArgs({...installationArgs, smpeDir: e.target.value}));
+                setSmpePath(e.target.value)
+            }}
         />
+    </FormControl>}
+    {installValue === "smpe" && <FormControl sx={{display: 'flex', alignItems: 'center', maxWidth: '72ch', justifyContent: 'center'}}>
+        <Button sx={{boxShadow: 'none', mr: '12px'}} type={"submit"} variant="text" onClick={async e => {
+            e.preventDefault();
+            window.electron.ipcRenderer.checkDirExists(connectionArgs, smpePath).then((res: boolean) => {
+                setSmpePathValidated(res);
+            })
+        }}>Validate location</Button>
+        {smpePathValidated ? <CheckCircleOutlineIcon color="success" sx={{ fontSize: 32 }}/> : <Typography sx={{color: "gray"}}>{'Enter a valid path.'}</Typography> }
     </FormControl>}
     {installValue === "download" && <Typography id="position-2" sx={{ mb: 1, whiteSpace: 'pre-wrap' }} color="text.secondary">       
         {`Zen will download the latest Zowe convenience build in PAX archive format from `}<Link href="zowe.org">{'https://zowe.org'}</Link>
@@ -91,6 +105,7 @@ const InstallationType = () => {
         {`Select a local Zowe PAX file (offline installation).`}
       </Typography>}
     {installValue === "upload" && <><Button sx={{boxShadow: 'none', mr: '12px'}} type="submit" variant="text" onClick={e => {
+        e.preventDefault();
         window.electron.ipcRenderer.uploadPax().then((res: any) => {
           if(res.filePaths && res.filePaths[0] != undefined){
             setPaxPath(res.filePaths[0]);

--- a/src/renderer/components/stages/installation/InstallTypeSelection.tsx
+++ b/src/renderer/components/stages/installation/InstallTypeSelection.tsx
@@ -94,8 +94,10 @@ const InstallationType = () => {
         window.electron.ipcRenderer.uploadPax().then((res: any) => {
           if(res.filePaths && res.filePaths[0] != undefined){
             setPaxPath(res.filePaths[0]);
+            dispatch(setInstallationArgs({...installationArgs, userUploadedPaxPath: res.filePaths[0]}));
           } else {
             setPaxPath("");
+            dispatch(setInstallationArgs({...installationArgs, userUploadedPaxPath: ''}));
           }
         });
       }}>Upload PAX</Button>

--- a/src/renderer/components/stages/installation/InstallTypeSelection.tsx
+++ b/src/renderer/components/stages/installation/InstallTypeSelection.tsx
@@ -9,11 +9,11 @@
  */
 
 import React, {useEffect, useRef, useState} from "react";
-import { Box, Button, FormControl, FormControlLabel, FormLabel, Link, Radio, RadioGroup, Typography } from '@mui/material';
+import { Box, Button, FormControl, FormControlLabel, FormLabel, Link, Radio, RadioGroup, TextField, Typography } from '@mui/material';
 import ContainerCard from '../../common/ContainerCard';
 import { useAppSelector, useAppDispatch } from '../../../hooks';
 import { selectYaml, setYaml, selectSchema, setNextStepEnabled, setLoading } from '../../configuration-wizard/wizardSlice';
-import { selectInstallationArgs, selectZoweVersion } from './installationSlice';
+import { selectInstallationArgs, selectZoweVersion, setInstallationArgs } from './installationSlice';
 import { selectConnectionArgs } from '../connection/connectionSlice';
 import JsonForm from '../../common/JsonForms';
 import { IResponse } from '../../../../types/interfaces';
@@ -31,6 +31,7 @@ const InstallationType = () => {
 //   const [setupYaml, setSetupYaml] = useState(yaml.zowe.setup.dataset);
   const [installValue, setInstallValue] = useState("download");
   const [paxPath, setPaxPath] = useState("");
+  const [smpePath, setSmpePath] = useState("");
 
   const installationArgs = useAppSelector(selectInstallationArgs);
   const version = useAppSelector(selectZoweVersion);
@@ -39,7 +40,7 @@ const InstallationType = () => {
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    if((installValue === "upload" && paxPath == "") || installValue === "smpe"){
+    if((installValue === "upload" && paxPath == "") || installValue === "smpe" && installationArgs.smpeDir == ""){
         dispatch(setNextStepEnabled(false));
     } else {
         dispatch(setNextStepEnabled(true));
@@ -58,7 +59,10 @@ const InstallationType = () => {
             aria-labelledby="demo-radio-buttons-group-label"
             defaultValue="download"
             name="radio-buttons-group"
-            onChange={(e) => setInstallValue(e.target.value)}
+            onChange={(e) => {
+                dispatch(setInstallationArgs({...installationArgs, installationType: e.target.value}))
+                setInstallValue(e.target.value)
+            }}
         >
             <FormControlLabel value="download" control={<Radio />} label="Download Zowe convenience build PAX from internet" />
             <FormControlLabel value="upload" control={<Radio />} label="Upload Zowe PAX for offline install" />
@@ -66,8 +70,20 @@ const InstallationType = () => {
         </RadioGroup>
     </FormControl>
     {installValue === "smpe" && <Typography id="position-2" sx={{ mb: 1, whiteSpace: 'pre-wrap' }} color="text.secondary">       
-        {`SMP/E installation is currently unsupported by Zen. Please complete the SMP/E installation steps for Zowe manually, then return to the Zen application after install is complete.`}
+        {`SMP/E installation must be done outside of ZEN. Return to ZEN and input the location Zowe was installed to before continuing.`}
     </Typography>}
+    {installValue === "smpe" && <FormControl>
+        <TextField 
+            id="smpe-install-path"
+            required
+            style={{marginLeft: 0}}
+            label="SMPE Installation Location"
+            variant="standard"
+            helperText="Location of Zowe SMPE installation."
+            value={installationArgs.smpeDir}
+            onChange={(e) => dispatch(setInstallationArgs({...installationArgs, smpeDir: e.target.value}))}
+        />
+    </FormControl>}
     {installValue === "download" && <Typography id="position-2" sx={{ mb: 1, whiteSpace: 'pre-wrap' }} color="text.secondary">       
         {`Zen will download the latest Zowe convenience build in PAX archive format from `}<Link href="zowe.org">{'https://zowe.org'}</Link>
     </Typography>}

--- a/src/renderer/components/stages/installation/InstallTypeSelection.tsx
+++ b/src/renderer/components/stages/installation/InstallTypeSelection.tsx
@@ -46,7 +46,7 @@ const InstallationType = () => {
         dispatch(setNextStepEnabled(true));
     }
     
-  }, [installValue, paxPath]);
+  }, [installValue, paxPath, installationArgs]);
 
 
   return (

--- a/src/renderer/components/stages/installation/installationSlice.ts
+++ b/src/renderer/components/stages/installation/installationSlice.ts
@@ -17,6 +17,7 @@ interface InstallationState {
     installationDir: string;
     installationType?: string;
     downloadDir: string;
+    userUploadedPaxPath?: string;
     smpeDir?: string;
     javaHome: string;
     nodeHome: string;
@@ -30,6 +31,7 @@ const initialState: InstallationState = {
   installationArgs: {
     installationDir: '',
     installationType: 'download',
+    userUploadedPaxPath: '',
     smpeDir: '',
     downloadDir: '',
     javaHome: '',

--- a/src/renderer/components/stages/installation/installationSlice.ts
+++ b/src/renderer/components/stages/installation/installationSlice.ts
@@ -15,7 +15,9 @@ interface InstallationState {
   installationStatus: boolean;
   installationArgs: {
     installationDir: string;
+    installationType?: string;
     downloadDir: string;
+    smpeDir?: string;
     javaHome: string;
     nodeHome: string;
     setupConfig: any;
@@ -27,6 +29,8 @@ const initialState: InstallationState = {
   installationStatus: false,
   installationArgs: {
     installationDir: '',
+    installationType: 'download',
+    smpeDir: '',
     downloadDir: '',
     javaHome: '',
     nodeHome: '',

--- a/src/renderer/preload.ts
+++ b/src/renderer/preload.ts
@@ -34,6 +34,9 @@ contextBridge.exposeInMainWorld('electron', {
     checkZoweCLI() {
       return ipcRenderer.invoke("check-zowe-cli");
     },
+    uploadPax(){
+      return ipcRenderer.invoke('upload-pax')
+    },
     findPreviousInstallations() {
       return ipcRenderer.invoke("get-installation-history");
     },

--- a/src/renderer/preload.ts
+++ b/src/renderer/preload.ts
@@ -55,6 +55,9 @@ contextBridge.exposeInMainWorld('electron', {
     checkSpace(connectionArgs: IIpcConnectionArgs, location: string) {
       return ipcRenderer.invoke("check-space", connectionArgs, location);
     },
+    checkDirExists(connectionArgs: IIpcConnectionArgs, location: string) {
+      return ipcRenderer.invoke("check-dir-exists", connectionArgs, location);
+    },
     installButtonOnClick(connectionArgs: IIpcConnectionArgs, installationArgs: {installDir: string, javaHome: string, nodeHome: string, installationType: string, userUploadedPaxPath: string}, version: string) {
       return ipcRenderer.invoke("install-mvs", connectionArgs, installationArgs, version);
     },

--- a/src/renderer/preload.ts
+++ b/src/renderer/preload.ts
@@ -55,7 +55,7 @@ contextBridge.exposeInMainWorld('electron', {
     checkSpace(connectionArgs: IIpcConnectionArgs, location: string) {
       return ipcRenderer.invoke("check-space", connectionArgs, location);
     },
-    installButtonOnClick(connectionArgs: IIpcConnectionArgs, installationArgs: {installDir: string, javaHome: string, nodeHome: string}, version: string) {
+    installButtonOnClick(connectionArgs: IIpcConnectionArgs, installationArgs: {installDir: string, javaHome: string, nodeHome: string, installationType: string, userUploadedPaxPath: string}, version: string) {
       return ipcRenderer.invoke("install-mvs", connectionArgs, installationArgs, version);
     },
     getInstallationProgress() {


### PR DESCRIPTION
This pull request implements the following feature:

- Add a stage which allows the user to select from the following installation types:
  - Download Zowe PAX from internet (not yet implemented)
  - Upload offline PAX (needs FTP upload functionality)
  - SMP/E install (shows message that SMP/E install is unsupported via Zen and must be completed manually)