### PR TITLE
Add Stage to Run 'zwe init apfauth`

### DIFF
--- a/src/actions/InstallActions.ts
+++ b/src/actions/InstallActions.ts
@@ -41,4 +41,10 @@ export class InstallActions {
     version: string): Promise<IResponse> {
     return this.strategy.runInstallation(connectionArgs, installationArgs, version);
   }
+
+  apfAuth(connectionArgs: IIpcConnectionArgs,
+    installationArgs: {installationDir: string}, zoweConfig: any): Promise<IResponse> {
+    return this.strategy.apfAuth(connectionArgs, installationArgs, zoweConfig);
+  }
+
 }

--- a/src/actions/InstallationHandler.ts
+++ b/src/actions/InstallationHandler.ts
@@ -114,39 +114,37 @@ class Installation {
     }
   }
 
-<<<<<<< HEAD
   public async apfAuth(connectionArgs: IIpcConnectionArgs,
     installationArgs: {installationDir: string}, zoweConfig: any): Promise<any>{
-=======
+    console.log('writing current yaml to disk');
+    const filePath = path.join(app.getPath('temp'), 'zowe.yaml')
+    await fs.writeFile(filePath, stringify(zoweConfig), (err: any) => {
+      if (err) {
+          console.warn("Can't save configuration to zowe.yaml");
+          return ProgressStore.set('apfAuth.writeYaml', false);
+      }
+    });
+    ProgressStore.set('apfAuth.writeYaml', true);
+    console.log("uploading yaml...");
+    const uploadYaml = await this.uploadYaml(connectionArgs, installationArgs.installationDir);
+    if(!uploadYaml.status){
+      return ProgressStore.set('apfAuth.uploadYaml', false);;
+
+    }
+    ProgressStore.set('apfAuth.uploadYaml', uploadYaml.status);
+    const script = `cd ${installationArgs.installationDir}/runtime/bin;\n./zwe init apfauth -c ${installationArgs.installationDir}/zowe.yaml`;
+    const result = await new Script().run(connectionArgs, script);
+    ProgressStore.set('apfAuth.success', result.rc === 0);
+    return {status: result.rc === 0, details: result.jobOutput}
+  }
+  
   public async initSecurity(connectionArgs: IIpcConnectionArgs,
     installationArgs: {installationDir: string}, zoweConfig: any): Promise<IResponse>{
->>>>>>> v2.x/staging
       console.log('writing current yaml to disk');
       const filePath = path.join(app.getPath('temp'), 'zowe.yaml')
       await fs.writeFile(filePath, stringify(zoweConfig), (err: any) => {
         if (err) {
             console.warn("Can't save configuration to zowe.yaml");
-<<<<<<< HEAD
-            return ProgressStore.set('apfAuth.writeYaml', false);
-        }
-      });
-      ProgressStore.set('apfAuth.writeYaml', true);
-      console.log("uploading yaml...");
-      const uploadYaml = await this.uploadYaml(connectionArgs, installationArgs.installationDir);
-      if(!uploadYaml.status){
-        return ProgressStore.set('apfAuth.uploadYaml', false);;
-
-      }
-      ProgressStore.set('apfAuth.uploadYaml', uploadYaml.status);
-      const script = `cd ${installationArgs.installationDir}/runtime/bin;\n./zwe init apfauth -c ${installationArgs.installationDir}/zowe.yaml`;
-      const result = await new Script().run(connectionArgs, script);
-      ProgressStore.set('apfAuth.success', result.rc === 0);
-      return {status: result.rc === 0, details: result.jobOutput}
-    }
-
-  async generateYamlFile() {
-    const zoweYaml: any = ConfigurationStore.getConfig();
-=======
             ProgressStore.set('initSecurity.writeYaml', false);
             return {status: false, details: `Can't save configuration to zowe.yaml`};
         }
@@ -165,7 +163,6 @@ class Installation {
   }
 
   async generateYamlFile(zoweConfig: any) {
->>>>>>> v2.x/staging
     const filePath = path.join(app.getPath('temp'), 'zowe.yaml')
     await fs.writeFile(filePath, stringify(zoweConfig), (err: any) => {
       if (err) {

--- a/src/actions/InstallationHandler.ts
+++ b/src/actions/InstallationHandler.ts
@@ -72,6 +72,30 @@ class Installation {
     }
   }
 
+  public async apfAuth(connectionArgs: IIpcConnectionArgs,
+    installationArgs: {installationDir: string}, zoweConfig: any): Promise<any>{
+      console.log('writing current yaml to disk');
+      const filePath = path.join(app.getPath('temp'), 'zowe.yaml')
+      await fs.writeFile(filePath, stringify(zoweConfig), (err: any) => {
+        if (err) {
+            console.warn("Can't save configuration to zowe.yaml");
+            return ProgressStore.set('apfAuth.writeYaml', false);
+        }
+      });
+      ProgressStore.set('apfAuth.writeYaml', true);
+      console.log("uploading yaml...");
+      const uploadYaml = await this.uploadYaml(connectionArgs, installationArgs.installationDir);
+      if(!uploadYaml.status){
+        return ProgressStore.set('apfAuth.uploadYaml', false);;
+
+      }
+      ProgressStore.set('apfAuth.uploadYaml', uploadYaml.status);
+      const script = `cd ${installationArgs.installationDir}/runtime/bin;\n./zwe init apfauth -c ${installationArgs.installationDir}/zowe.yaml`;
+      const result = await new Script().run(connectionArgs, script);
+      ProgressStore.set('apfAuth.success', result.rc === 0);
+      return {status: result.rc === 0, details: result.jobOutput}
+    }
+
   async generateYamlFile() {
     const zoweYaml: any = ConfigurationStore.getConfig();
     const filePath = path.join(app.getPath('temp'), 'zowe.yaml')

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -130,6 +130,18 @@ const createWindow = (): void => {
     return res;
   });
 
+  ipcMain.handle('init-apf', async (event, connectionArgs, installationArgs, zoweConfig) => {
+    const res = await installActions.apfAuth(connectionArgs, installationArgs, zoweConfig);
+    return res;
+  });
+
+
+  ipcMain.handle('get-apf-auth-progress', async (event) => {
+    const res = ProgressStore.getAll()['apfAuth'];
+    return res;
+  });
+
+
   ipcMain.handle('get-installation-progress', async (event) => {
     const res = ProgressStore.getAll()['installation'];
     return res;

--- a/src/renderer/components/configuration-wizard/Wizard.tsx
+++ b/src/renderer/components/configuration-wizard/Wizard.tsx
@@ -27,7 +27,7 @@ const stages = [
   {id: 2, label: 'Installation Type', component: <InstallationType/>, hasJCL: false, isSkippable: false, hasOutput: false, steps: 1, nextButton: 'Continue to Components Installation'},
   {id: 3, label: 'Initialization', component: <Initialization/>, hasJCL: true, isSkippable: true, hasYaml: true, hasOutput: true, steps: 1, subStages: [
     {id: 0, label: 'Installation', component: <Installation/>, hasJCL: true, isSkippable: true, hasYaml: true, hasOutput: true, steps: 1, nextButton: 'Continue to APF Auth Setup'},
-    {id: 1, label: 'Initialize APF Auth', component: <InitApfAuth/>, hasJCL: true, isSkippable: true, hasYaml: true, hasOutput: true, steps: 1, nextButton: 'Continue to Security Setup'},
+    {id: 1, label: 'APF Auth', component: <InitApfAuth/>, hasJCL: true, isSkippable: true, hasYaml: true, hasOutput: true, steps: 1, nextButton: 'Continue to Security Setup'},
     {id: 2, label: 'Security', component: <Security/>, hasJCL: true, isSkippable: true, hasYaml: true, hasOutput: true, steps: 1, nextButton: 'Continue to Certificates Setup'},
     {id: 3, label: 'Certificates', component: <Certificates/>, hasJCL: true, isSkippable: true, hasYaml: true, hasOutput: true, steps: 1, nextButton: 'Continue to Instance Setup'},
   ], nextButton: <div style={{display: 'flex', alignItems: 'center'}}><img style={{width: '18px', height: '18px', paddingRight: '12px'}} src={spock}/>Live long and prosper</div>},

--- a/src/renderer/components/configuration-wizard/Wizard.tsx
+++ b/src/renderer/components/configuration-wizard/Wizard.tsx
@@ -26,9 +26,10 @@ const stages = [
   {id: 1, label: 'Planning', component: <Planning/>, hasJCL: false, isSkippable: false, hasOutput: true, steps: 3, nextButton: 'Continue to Installation Options'},
   {id: 2, label: 'Installation Type', component: <InstallationType/>, hasJCL: false, isSkippable: false, hasOutput: false, steps: 1, nextButton: 'Continue to Components Installation'},
   {id: 3, label: 'Initialization', component: <Initialization/>, hasJCL: true, isSkippable: true, hasYaml: true, hasOutput: true, steps: 1, subStages: [
-    {id: 0, label: 'Installation', component: <Installation/>, hasJCL: true, isSkippable: true, hasYaml: true, hasOutput: true, steps: 1, nextButton: 'Continue to Security Setup'},
-    {id: 1, label: 'Security', component: <Security/>, hasJCL: true, isSkippable: true, hasYaml: true, hasOutput: true, steps: 1, nextButton: 'Continue to Certificates Setup'},
-    {id: 2, label: 'Certificates', component: <Certificates/>, hasJCL: true, isSkippable: true, hasYaml: true, hasOutput: true, steps: 1, nextButton: 'Continue to Instance Setup'},
+    {id: 0, label: 'Installation', component: <Installation/>, hasJCL: true, isSkippable: true, hasYaml: true, hasOutput: true, steps: 1, nextButton: 'Continue to APF Auth Setup'},
+    {id: 1, label: 'Initialize APF Auth', component: <InitApfAuth/>, hasJCL: true, isSkippable: true, hasYaml: true, hasOutput: true, steps: 1, nextButton: 'Continue to Security Setup'},
+    {id: 2, label: 'Security', component: <Security/>, hasJCL: true, isSkippable: true, hasYaml: true, hasOutput: true, steps: 1, nextButton: 'Continue to Certificates Setup'},
+    {id: 3, label: 'Certificates', component: <Certificates/>, hasJCL: true, isSkippable: true, hasYaml: true, hasOutput: true, steps: 1, nextButton: 'Continue to Instance Setup'},
   ], nextButton: <div style={{display: 'flex', alignItems: 'center'}}><img style={{width: '18px', height: '18px', paddingRight: '12px'}} src={spock}/>Live long and prosper</div>},
 ]
 

--- a/src/renderer/components/configuration-wizard/Wizard.tsx
+++ b/src/renderer/components/configuration-wizard/Wizard.tsx
@@ -19,15 +19,17 @@ import spock from '../../assets/spock.svg'
 import InstallationType from '../stages/installation/InstallTypeSelection';
 import { selectLoading } from './wizardSlice';
 import { useAppSelector } from '../../hooks';
+import InitApfAuth from '../stages/InitApfAuth';
 
 const stages = [
   {id: 0, label: 'Connection', component: <Connection/>, nextButton: 'Continue'},
   {id: 1, label: 'Planning', component: <Planning/>, nextButton: 'Continue to installation options'},
   {id: 2, label: 'Installation Type', component: <InstallationType/>, nextButton: 'Continue to components installation'},
-  {id: 3, label: 'Installation', component: <Installation/>, nextButton: 'Continue to zowe Security'},
-  {id: 4, label: 'Security', component: <Security/>, nextButton: 'Continue to certificates setup'},
-  {id: 5, label: 'Certificates', component: <Certificates/>, nextButton: 'Continue to instance setup'},
-  {id: 6, label: 'Initialization', component: <Initialization/>, nextButton: <div style={{display: 'flex', alignItems: 'center'}}><img style={{width: '18px', height: '18px', paddingRight: '12px'}} src={spock}/>Live long and prosper</div>},
+  {id: 3, label: 'Installation', component: <Installation/>, nextButton: 'Continue to APF authorization'},
+  {id: 4, label: 'Initialize APF Auth', component: <InitApfAuth/>, nextButton: 'Continue to zowe Security'},
+  {id: 5, label: 'Security', component: <Security/>, nextButton: 'Continue to certificates setup'},
+  {id: 6, label: 'Certificates', component: <Certificates/>, nextButton: 'Continue to instance setup'},
+  {id: 7, label: 'Initialization', component: <Initialization/>, nextButton: <div style={{display: 'flex', alignItems: 'center'}}><img style={{width: '18px', height: '18px', paddingRight: '12px'}} src={spock}/>Live long and prosper</div>},
 ]
 
 const Wizard = () => {

--- a/src/renderer/components/stages/InitApfAuth.tsx
+++ b/src/renderer/components/stages/InitApfAuth.tsx
@@ -8,16 +8,15 @@
  * Copyright Contributors to the Zowe Project.
  */
 
-import React, {useEffect, useRef, useState} from "react";
+import React, {useEffect, useState} from "react";
 import { Box, Button, FormControl, TextField, Typography } from '@mui/material';
 import { useAppSelector, useAppDispatch } from '../../hooks';
-import { selectYaml, setYaml, selectSchema, setNextStepEnabled, setLoading } from '../configuration-wizard/wizardSlice';
+import { selectYaml, selectSchema, setNextStepEnabled, setLoading } from '../configuration-wizard/wizardSlice';
 import { selectConnectionArgs } from './connection/connectionSlice';
 import { IResponse } from '../../../types/interfaces';
 import { setConfiguration, getConfiguration, getZoweConfig } from '../../../services/ConfigService';
 import ProgressCard from '../common/ProgressCard';
 import ContainerCard from '../common/ContainerCard';
-import JsonForm from '../common/JsonForms';
 import EditorDialog from "../common/EditorDialog";
 import Ajv from "ajv";
 import { selectInstallationArgs } from "./installation/installationSlice";
@@ -133,9 +132,6 @@ const InitApfAuth = () => {
 
   return (
     <div>
-      <div style={{ position: 'fixed', top: '140px', right: '30px'}}>
-        <Button style={{ color: 'white', backgroundColor: '#1976d2', fontSize: 'x-small'}} onClick={toggleEditorVisibility}>Open Editor</Button>
-      </div>
       <ContainerCard title="APF Authorize Load Libraries" description="Run the `zwe init apfauth` command to APF authorize load libraries."> 
         <EditorDialog isEditorVisible={editorVisible} toggleEditorVisibility={toggleEditorVisibility} onChange={editHLQ}/>
         <Typography id="position-2" sx={{ mb: 1, whiteSpace: 'pre-wrap', marginBottom: '50px', color: 'text.secondary', fontSize: '13px' }}>

--- a/src/renderer/components/stages/InitApfAuth.tsx
+++ b/src/renderer/components/stages/InitApfAuth.tsx
@@ -157,7 +157,6 @@ const InitApfAuth = () => {
                 multiline
                 maxRows={6}
                 value={setupYaml.prefix}
-                onChange={(e) => {}}
                 variant="filled"
                 disabled
             />
@@ -169,7 +168,6 @@ const InitApfAuth = () => {
                 multiline
                 maxRows={6}
                 value={setupYaml.authLoadlib}
-                onChange={(e) => {}}
                 variant="filled"
                 disabled
             />
@@ -181,7 +179,6 @@ const InitApfAuth = () => {
                 multiline
                 maxRows={6}
                 value={setupYaml.authPluginLib}
-                onChange={(e) => {}}
                 variant="filled"
                 disabled
             />

--- a/src/renderer/components/stages/InitApfAuth.tsx
+++ b/src/renderer/components/stages/InitApfAuth.tsx
@@ -136,7 +136,7 @@ const InitApfAuth = () => {
       <div style={{ position: 'fixed', top: '140px', right: '30px'}}>
         <Button style={{ color: 'white', backgroundColor: '#1976d2', fontSize: 'x-small'}} onClick={toggleEditorVisibility}>Open Editor</Button>
       </div>
-      <ContainerCard title="zwe init apfauth" description="Run the zwe command to initialize apf authorizations."> 
+      <ContainerCard title="APF Authorize Load Libraries" description="Run the `zwe init apfauth` command to APF authorize load libraries."> 
         <EditorDialog isEditorVisible={editorVisible} toggleEditorVisibility={toggleEditorVisibility} onChange={editHLQ}/>
         <Typography id="position-2" sx={{ mb: 1, whiteSpace: 'pre-wrap', marginBottom: '50px', color: 'text.secondary', fontSize: '13px' }}>
           {`Ready to submit the 'zwe init apfauth' command and APF authorize the Zowe load libraries.\n`}

--- a/src/renderer/components/stages/InitApfAuth.tsx
+++ b/src/renderer/components/stages/InitApfAuth.tsx
@@ -139,7 +139,7 @@ const InitApfAuth = () => {
       <ContainerCard title="APF Authorize Load Libraries" description="Run the `zwe init apfauth` command to APF authorize load libraries."> 
         <EditorDialog isEditorVisible={editorVisible} toggleEditorVisibility={toggleEditorVisibility} onChange={editHLQ}/>
         <Typography id="position-2" sx={{ mb: 1, whiteSpace: 'pre-wrap', marginBottom: '50px', color: 'text.secondary', fontSize: '13px' }}>
-          {`Ready to submit the 'zwe init apfauth' command and APF authorize the Zowe load libraries.\n`}
+          {`Please review the following dataset setup configuration values before pressing run.\n`}
         </Typography>
         <Box sx={{ width: '60vw' }}>
             <TextField

--- a/src/renderer/components/stages/InitApfAuth.tsx
+++ b/src/renderer/components/stages/InitApfAuth.tsx
@@ -1,0 +1,200 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+import React, {useEffect, useRef, useState} from "react";
+import { Box, Button, FormControl, TextField, Typography } from '@mui/material';
+import { useAppSelector, useAppDispatch } from '../../hooks';
+import { selectYaml, setYaml, selectSchema, setNextStepEnabled, setLoading } from '../configuration-wizard/wizardSlice';
+import { selectConnectionArgs } from './connection/connectionSlice';
+import { IResponse } from '../../../types/interfaces';
+import { setConfiguration, getConfiguration, getZoweConfig } from '../../../services/ConfigService';
+import ProgressCard from '../common/ProgressCard';
+import ContainerCard from '../common/ContainerCard';
+import JsonForm from '../common/JsonForms';
+import EditorDialog from "../common/EditorDialog";
+import Ajv from "ajv";
+import { selectInstallationArgs } from "./installation/installationSlice";
+
+const InitApfAuth = () => {
+
+  // TODO: Display granular details of installation - downloading - unpacking - running zwe command
+
+  const dispatch = useAppDispatch();
+  const schema = useAppSelector(selectSchema);
+  const yaml = useAppSelector(selectYaml);
+  const connectionArgs = useAppSelector(selectConnectionArgs);
+  const setupSchema = schema ? schema.properties.zowe.properties.setup.properties.dataset : "";
+  const [setupYaml, setSetupYaml] = useState(yaml?.zowe.setup.dataset);
+  const [showProgress, toggleProgress] = useState(false);
+  const [init, setInit] = useState(false);
+  const [editorVisible, setEditorVisible] = useState(false);
+  const [isFormValid, setIsFormValid] = useState(false);
+  const [formError, setFormError] = useState('');
+  const [apfProgress, setApfProgress] = useState({
+    writeYaml: false,
+    uploadYaml: false,
+    success: false,
+  });
+
+  const installationArgs = useAppSelector(selectInstallationArgs);
+  let timer: any;
+
+  const section = 'dataset';
+  const initConfig = getConfiguration(section);
+
+  const ajv = new Ajv();
+  ajv.addKeyword("$anchor");
+  let datasetSchema;
+  let validate: any;
+  if(schema) {
+    datasetSchema = schema.properties.zowe.properties.setup.properties.dataset;
+  }
+
+  if(datasetSchema) {
+    validate = ajv.compile(datasetSchema);
+  }
+  
+  useEffect(() => {
+    dispatch(setNextStepEnabled(false));
+    if(Object.keys(initConfig) && Object.keys(initConfig).length != 0) {
+      setSetupYaml(initConfig);
+    }
+    setInit(true);
+  }, []);
+
+  useEffect(() => {
+    timer = setInterval(() => {
+      window.electron.ipcRenderer.getApfAuthProgress().then((res: any) => {
+        setApfProgress(res);
+      })
+    }, 3000);
+    const nextPosition = document.getElementById('apf-progress');
+    nextPosition.scrollIntoView({behavior: 'smooth'});
+  }, [showProgress]);
+
+  const toggleEditorVisibility = () => {
+    setEditorVisible(!editorVisible);
+  };
+
+  const process = (event: any) => {
+    event.preventDefault();
+    toggleProgress(true);
+    window.electron.ipcRenderer.apfAuthButtonOnClick(connectionArgs, installationArgs, getZoweConfig()).then((res: IResponse) => {
+        dispatch(setNextStepEnabled(res.status));
+        clearInterval(timer);
+      }).catch(() => {
+        clearInterval(timer);
+        console.warn('zwe init apfauth failed');
+      });
+  }
+
+  const editHLQ = (data: any, isYamlUpdated?: boolean) => {
+    let updatedData = init ? (Object.keys(initConfig).length > 0 ? initConfig: data) : (data ? data : initConfig);
+    
+    setInit(false);
+
+    updatedData = isYamlUpdated ? data.dataset : updatedData;
+    if (updatedData && setupYaml && setupYaml.prefix !== updatedData.prefix) {
+      const newPrefix = updatedData.prefix ? updatedData.prefix : '';
+      const newData = Object.keys(setupYaml).reduce((acc, k) => {
+        if (typeof(setupYaml[k]) === 'string' && setupYaml[k].startsWith(`${setupYaml.prefix}.`)) {
+          return {...acc, [k]: setupYaml[k].replace(setupYaml.prefix, newPrefix), prefix: newPrefix}
+        }
+        return {...acc, [k]: setupYaml[k]}
+      }, {});
+    }
+
+    if(validate) {
+      validate(updatedData);
+      if(validate.errors) {
+        const errPath = validate.errors[0].schemaPath;
+        const errMsg = validate.errors[0].message;
+        setStageConfig(false, errPath+' '+errMsg, updatedData, false);
+      } else {
+        setConfiguration(section, updatedData, true);
+        setStageConfig(true, '', updatedData, true);
+      }
+    }
+  }
+
+  const setStageConfig = (isValid: boolean, errorMsg: string, data: any, proceed: boolean) => {
+    setIsFormValid(isValid);
+    setFormError(errorMsg);
+    setSetupYaml(data);
+    dispatch(setNextStepEnabled(proceed));
+  }
+
+  return (
+    <div>
+      <div style={{ position: 'fixed', top: '140px', right: '30px'}}>
+        <Button style={{ color: 'white', backgroundColor: '#1976d2', fontSize: 'x-small'}} onClick={toggleEditorVisibility}>Open Editor</Button>
+      </div>
+      <ContainerCard title="zwe init apfauth" description="Run the zwe command to initialize apf authorizations."> 
+        <EditorDialog isEditorVisible={editorVisible} toggleEditorVisibility={toggleEditorVisibility} onChange={editHLQ}/>
+        <Typography id="position-2" sx={{ mb: 1, whiteSpace: 'pre-wrap', marginBottom: '50px', color: 'text.secondary', fontSize: '13px' }}>
+          {`Ready to submit the 'zwe init apfauth' command and APF authorize the Zowe load libraries.\n`}
+        </Typography>
+        <Box sx={{ width: '60vw' }}>
+            <TextField
+                sx={{
+                '& .MuiInputBase-root': { height: '60px', minWidth: '72ch', fontFamily: 'monospace' },
+                }}
+                label="Dataset Prefix"
+                multiline
+                maxRows={6}
+                value={setupYaml.prefix}
+                onChange={(e) => {}}
+                variant="filled"
+                disabled
+            />
+            <TextField
+                sx={{
+                '& .MuiInputBase-root': { height: '60px', minWidth: '72ch', fontFamily: 'monospace' },
+                }}
+                label="APF Authorized Load Library"
+                multiline
+                maxRows={6}
+                value={setupYaml.authLoadlib}
+                onChange={(e) => {}}
+                variant="filled"
+                disabled
+            />
+            <TextField
+                sx={{
+                '& .MuiInputBase-root': { height: '60px', minWidth: '72ch', fontFamily: 'monospace' },
+                }}
+                label="Zowe ZIS Plugins Load Library"
+                multiline
+                maxRows={6}
+                value={setupYaml.authPluginLib}
+                onChange={(e) => {}}
+                variant="filled"
+                disabled
+            />
+        </Box>
+        {!showProgress ? <FormControl sx={{display: 'flex', alignItems: 'center', maxWidth: '72ch', justifyContent: 'center'}}>
+          <Button sx={{boxShadow: 'none', mr: '12px'}} type="submit" variant="text" onClick={e => process(e)}>Run 'zwe init apfauth'</Button>
+        </FormControl> : null}
+        <Box sx={{height: showProgress ? 'calc(100vh - 220px)' : 'auto'}} id="apf-progress">
+        {!showProgress ? null :
+          <React.Fragment>
+            <ProgressCard label="Write configuration file locally to temp directory" id="download-progress-card" status={apfProgress.writeYaml}/>
+            <ProgressCard label={`Upload configuration file to ${installationArgs.installationDir}`} id="download-progress-card" status={apfProgress.uploadYaml}/>
+            <ProgressCard label={`Run zwe init apfauth command`} id="upload-progress-card" status={apfProgress.success}/>
+          </React.Fragment>
+        }
+        </Box> 
+      </ContainerCard>
+    </div>
+    
+  );
+};
+
+export default InitApfAuth;

--- a/src/renderer/components/stages/InitApfAuth.tsx
+++ b/src/renderer/components/stages/InitApfAuth.tsx
@@ -20,10 +20,13 @@ import ContainerCard from '../common/ContainerCard';
 import EditorDialog from "../common/EditorDialog";
 import Ajv from "ajv";
 import { selectInstallationArgs } from "./installation/installationSlice";
+import { createTheme } from '@mui/material/styles';
 
 const InitApfAuth = () => {
 
   // TODO: Display granular details of installation - downloading - unpacking - running zwe command
+
+  const theme = createTheme();
 
   const dispatch = useAppDispatch();
   const schema = useAppSelector(selectSchema);
@@ -36,6 +39,7 @@ const InitApfAuth = () => {
   const [editorVisible, setEditorVisible] = useState(false);
   const [isFormValid, setIsFormValid] = useState(false);
   const [formError, setFormError] = useState('');
+  const [contentType, setContentType] = useState('');
   const [apfProgress, setApfProgress] = useState({
     writeYaml: false,
     uploadYaml: false,
@@ -78,7 +82,9 @@ const InitApfAuth = () => {
     nextPosition.scrollIntoView({behavior: 'smooth'});
   }, [showProgress]);
 
-  const toggleEditorVisibility = () => {
+
+  const toggleEditorVisibility = (type: any) => {
+    setContentType(type);
     setEditorVisible(!editorVisible);
   };
 
@@ -132,8 +138,13 @@ const InitApfAuth = () => {
 
   return (
     <div>
-      <ContainerCard title="APF Authorize Load Libraries" description="Run the `zwe init apfauth` command to APF authorize load libraries."> 
-        <EditorDialog isEditorVisible={editorVisible} toggleEditorVisibility={toggleEditorVisibility} onChange={editHLQ}/>
+      <ContainerCard title="APF Authorize Load Libraries" description="Run the `zwe init apfauth` command to APF authorize load libraries.">
+      <Box sx={{ position:'absolute', bottom: '1px', display: 'flex', flexDirection: 'row', p: 1, justifyContent: 'flex-start', [theme.breakpoints.down('lg')]: {flexDirection: 'column',alignItems: 'flex-start'}}}>
+        <Button variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility("yaml")}>View Yaml</Button>
+        <Button variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility("jcl")}>View/Submit Job</Button>
+        <Button variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility("output")}>View Job Output</Button>
+      </Box>
+      <EditorDialog contentType={contentType} isEditorVisible={editorVisible} toggleEditorVisibility={toggleEditorVisibility} onChange={editHLQ}/>
         <Typography id="position-2" sx={{ mb: 1, whiteSpace: 'pre-wrap', marginBottom: '50px', color: 'text.secondary', fontSize: '13px' }}>
           {`Please review the following dataset setup configuration values before pressing run.\n`}
         </Typography>

--- a/src/renderer/components/stages/InitApfAuth.tsx
+++ b/src/renderer/components/stages/InitApfAuth.tsx
@@ -62,7 +62,7 @@ const InitApfAuth = () => {
   }
   
   useEffect(() => {
-    dispatch(setNextStepEnabled(false));
+    // dispatch(setNextStepEnabled(false));
     if(Object.keys(initConfig) && Object.keys(initConfig).length != 0) {
       setSetupYaml(initConfig);
     }

--- a/src/renderer/preload.ts
+++ b/src/renderer/preload.ts
@@ -61,6 +61,12 @@ contextBridge.exposeInMainWorld('electron', {
     installButtonOnClick(connectionArgs: IIpcConnectionArgs, installationArgs: {installDir: string, javaHome: string, nodeHome: string, installationType: string, userUploadedPaxPath: string}, version: string) {
       return ipcRenderer.invoke("install-mvs", connectionArgs, installationArgs, version);
     },
+    apfAuthButtonOnClick(connectionArgs: IIpcConnectionArgs, installationArgs: {installDir: string}, zoweConfig: any) {
+      return ipcRenderer.invoke("init-apf", connectionArgs, installationArgs, zoweConfig);
+    },
+    getApfAuthProgress(){
+      return ipcRenderer.invoke("get-apf-auth-progress");
+    },
     getInstallationProgress() {
       return ipcRenderer.invoke("get-installation-progress");
     },

--- a/src/storage/ProgressStore.ts
+++ b/src/storage/ProgressStore.ts
@@ -19,6 +19,11 @@ const storeDefault = {
     "upload": false,
     "unpax": false,
     "install": false
+  },
+  "apfAuth":{
+    "writeYaml": false,
+    "uploadYaml": false,
+    "success": false
   }
 };
 


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
This pull request adds the following feature:
- Add stage to submit 'zwe init apfauth' command using previously entered dataset config
- Fields on stage are read only simply to show user what is about to be submitted with the zwe command
![image](https://github.com/zowe/zen/assets/7998484/19db08e4-f6df-494a-b6cd-2ec4a9ec0e84)



This PR depends upon the following PRs:

## Type of change
Please delete options that are not relevant.
- [X] New feature (non-breaking change which adds functionality)

## PR Checklist
Please delete options that are not relevant.
- [ ] If the changes in this PR are meant for the next release / mainline, this PR targets a "staging" branch.
- [ ] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zen/blob/v2.x/staging/CONTRIBUTING.md))
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
<!-- - [ ] Relevant update to CHANGELOG.md -->
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, or if there are follow-up tasks and TODOs etc... -->
