### PR TITLE
force install appdmg

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -75,12 +75,13 @@ jobs:
       - name: '[Prep 2] Setup Node'
         uses: actions/setup-node@v2
         with:
-          node-version: 18
+          node-version: 18.16
       - name: '[Prep 3] Checkout'
         uses: actions/checkout@v3
       - name: '[prep 4] Install'
         run: |
-          npm install     
+          rm -rf node_modules
+          npm ci
       - name: '[prep 5] Package'
         run: |
           npm run make  

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -80,8 +80,8 @@ jobs:
         uses: actions/checkout@v3
       - name: '[prep 4] Install'
         run: |
-          rm -rf node_modules
-          npm ci
+          rm -rf node_modules package-lock.json
+          npm i
       - name: '[prep 5] Package'
         run: |
           npm run make  

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/checkout@v3
       - name: '[prep 4] Install'
         run: |
+          python3 -m pip install setuptools
           rm -rf node_modules package-lock.json
           npm i
       - name: '[prep 5] Package'

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@electron-forge/cli": "^6.0.5",
     "@electron-forge/maker-deb": "^6.0.5",
-    "@electron-forge/maker-dmg": "^6.0.5",
+    "@electron-forge/maker-dmg": "~6.0.5",
     "@electron-forge/maker-rpm": "^6.0.5",
     "@electron-forge/maker-squirrel": "^6.0.5",
     "@electron-forge/maker-zip": "^6.0.5",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@typescript-eslint/eslint-plugin": "^5.52.0",
     "@typescript-eslint/parser": "^5.52.0",
     "@vercel/webpack-asset-relocator-loader": "^1.7.3",
+    "appdmg": "0.6.6",
     "css-loader": "^6.7.3",
     "electron": "22.0.0",
     "eslint": "^8.34.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@typescript-eslint/eslint-plugin": "^5.52.0",
     "@typescript-eslint/parser": "^5.52.0",
     "@vercel/webpack-asset-relocator-loader": "^1.7.3",
-    "appdmg": "0.6.6",
     "css-loader": "^6.7.3",
     "electron": "22.0.0",
     "eslint": "^8.34.0",
@@ -70,5 +69,8 @@
     "react-router-dom": "^6.8.1",
     "yaml": "^2.2.1",
     "zos-node-accessor": "^1.0.14"
+  },
+  "optionalDependencies": {
+    "appdmg": "0.6.6"
   }
 }


### PR DESCRIPTION
mac builds seem broken due to missing npm package "appdmg" even though it is in package-lock. maybe it just needs to be force=installed in package.json