### PR TITLE
Fix mac build

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/checkout@v3
       - name: '[prep 4] Install'
         run: |
+          python3 -m pip install setuptools
           npm install     
       - name: '[prep 5] Package'
         run: |


### PR DESCRIPTION
Workaround as seen in https://github.com/LinusU/node-appdmg/issues/234
https://github.com/electron/forge/issues/3371#issuecomment-1801388891 points out that the macos runner could be the cause of the issue, and I'm assuming that python 3.12 is in the macos runner, causing headaches as python is known to do.