### PR TITLE
Create directories for run-time, logs, extensions, workspace

### DIFF
--- a/src/actions/PlanningActions.ts
+++ b/src/actions/PlanningActions.ts
@@ -32,14 +32,23 @@ export class PlanningActions {
     return await new CheckNode().run(connectionArgs, location);
   }
 
-  public static async checkSpace(connectionArgs: IIpcConnectionArgs, location: string): Promise<IResponse> {
-    // TODO: Check if there is zowe.yaml in this dir already, use it.
+  public static async checkSpaceAndCreateDir(connectionArgs: IIpcConnectionArgs, location: string): Promise<IResponse> {
+    await this.checkOrCreateDir(connectionArgs, location);
+    return await new CheckSpace().run(connectionArgs, location);
+  }
+
+  public static async checkOrCreateDir(connectionArgs: IIpcConnectionArgs, location: string): Promise<IResponse> {
     const dirExists = await checkDirExists(connectionArgs, location);
     if (!dirExists) {
       const dirCreated = await makeDir(connectionArgs, location);
-      if (!dirCreated) return {status: false, details: `Can't create dir ${location}`}
+      if (!dirCreated) {
+        return Promise.resolve({status: false, details: `Can't create dir ${location}`});
+      } else {
+        return Promise.resolve({status: true, details: `Directory successfully created at ${location}`});
+      }
+    } else {
+      return Promise.resolve({status: true, details: `Directory already existed at ${location}`});
     }
-    return await new CheckSpace().run(connectionArgs, location);
   }
   
   public static getExampleZowe(): Promise<{status: boolean, details: any}> {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -115,13 +115,18 @@ const createWindow = (): void => {
     return res;
   });
 
-  ipcMain.handle('check-space', async (event, connectionArgs, location) => {
-    const res: any = await PlanningActions.checkSpace(connectionArgs, location);
+  ipcMain.handle('check-space-create-dir', async (event, connectionArgs, location) => {
+    const res: any = await PlanningActions.checkSpaceAndCreateDir(connectionArgs, location);
     return res;
   });
 
   ipcMain.handle('check-dir-exists', async (event, connectionArgs, location) => {
     const res: any = await checkDirExists(connectionArgs, location);
+    return res;
+  })
+
+  ipcMain.handle('check-dir-or-create', async (event, connectionArgs, location) => {
+    const res: any = await PlanningActions.checkOrCreateDir(connectionArgs, location);
     return res;
   })
 

--- a/src/renderer/components/stages/Planning.tsx
+++ b/src/renderer/components/stages/Planning.tsx
@@ -284,25 +284,48 @@ const Planning = () => {
     }
     dispatch(setLoading(true));
 
+    // TODO: Possible feature for future: add to checkDir to see if existing Zowe install exists.
+    // Then give the user ability to use existing zowe.yaml to auto-fill in fields from Zen
     Promise.all([
       window.electron.ipcRenderer.checkJava(connectionArgs, installationArgs.javaHome),
       window.electron.ipcRenderer.checkNode(connectionArgs, installationArgs.nodeHome),
-      //Do not check space because space on ZFS is dynamic. you can have more space than USS thinks.
+      window.electron.ipcRenderer.checkDirOrCreate(connectionArgs, installationArgs.installationDir),
+      window.electron.ipcRenderer.checkDirOrCreate(connectionArgs, installationArgs.workspaceDir),
+      window.electron.ipcRenderer.checkDirOrCreate(connectionArgs, installationArgs.extensionDir),
+      window.electron.ipcRenderer.checkDirOrCreate(connectionArgs, installationArgs.logDir),
     ]).then((res: Array<IResponse>) => {
       const details = {javaVersion: '', nodeVersion: '', spaceAvailableMb: '', error: ''};
-      setEditorContent(res.map(item=>item.details).join('\n'));
+      setEditorContent(res.map(item=>item?.details).join('\n'));
       setContentType('output');
+
+      // If res[?] doesn't exist, ?-th window.electronc.ipcRender call failed...
       try {
         details.javaVersion = res[0].details.split('\n').filter((i: string) => i.trim().startsWith('java version'))[0].trim().slice(14, -1);
       } catch (error) {
-        details.error = details.error + `Can't get java version; `;
+        details.error = details.error + `Can't get Java version `;
         console.warn(res[0].details);
       }
       try {
         details.nodeVersion = res[1].details.split('\n').filter((i: string) => i.trim().startsWith('v'))[0].slice(1);
       } catch (error) {
-        details.error = details.error + `Can't get node version; `;
+        details.error = details.error + `Can't get Node.js version `;
         console.warn(res[1].details);
+      }
+      if (res[2].status == false) { // Checking run-time directory existence or creating it failed?
+        details.error = details.error + res[2].details;
+        console.warn(res[2].details);
+      }
+      if (res[3].status == false) { // workspace directory
+        details.error = details.error + res[3].details;
+        console.warn(res[3].details);
+      }
+      if (res[4].status == false) { // extensions directory
+        details.error = details.error + res[4].details;
+        console.warn(res[4].details);
+      }
+      if (res[5].status == false) { // logs directory
+        details.error = details.error + res[5].details;
+        console.warn(res[5].details);
       }
       //Do not check space because space on ZFS is dynamic. you can have more space than USS thinks.
       // try {

--- a/src/renderer/preload.ts
+++ b/src/renderer/preload.ts
@@ -52,11 +52,14 @@ contextBridge.exposeInMainWorld('electron', {
     checkNode(connectionArgs: IIpcConnectionArgs, location: string) {
       return ipcRenderer.invoke("check-node", connectionArgs, location);
     },
-    checkSpace(connectionArgs: IIpcConnectionArgs, location: string) {
-      return ipcRenderer.invoke("check-space", connectionArgs, location);
+    checkSpaceAndCreateDir(connectionArgs: IIpcConnectionArgs, location: string) {
+      return ipcRenderer.invoke("check-space-create-dir", connectionArgs, location);
     },
     checkDirExists(connectionArgs: IIpcConnectionArgs, location: string) {
       return ipcRenderer.invoke("check-dir-exists", connectionArgs, location);
+    },
+    checkDirOrCreate(connectionArgs: IIpcConnectionArgs, location: string) {
+      return ipcRenderer.invoke("check-dir-or-create", connectionArgs, location);
     },
     installButtonOnClick(connectionArgs: IIpcConnectionArgs, installationArgs: {installDir: string, javaHome: string, nodeHome: string, installationType: string, userUploadedPaxPath: string, smpeDir: string}, version: string, zoweConfig: any) {
       return ipcRenderer.invoke("install-mvs", connectionArgs, installationArgs, version, zoweConfig);


### PR DESCRIPTION
This also fixes the regression with removing the Unix space check, that caused runtime directory to not get created