### PR TITLE
Adding better logic to handle Unix char limits in JCL scripts

### DIFF
--- a/src/actions/InstallationHandler.ts
+++ b/src/actions/InstallationHandler.ts
@@ -132,7 +132,7 @@ class Installation {
 
     }
     ProgressStore.set('apfAuth.uploadYaml', uploadYaml.status);
-    const script = `cd ${installationArgs.installationDir}/runtime/bin;\n./zwe init apfauth -c ${installationArgs.installationDir}/zowe.yaml \n--allow-overwritten --update-config`;
+    const script = `cd ${installationArgs.installationDir}/runtime/bin;./zwe init apfauth -c ${installationArgs.installationDir}/zowe.yaml --allow-overwritten --update-config`;
     const result = await new Script().run(connectionArgs, script);
     ProgressStore.set('apfAuth.success', result.rc === 0);
     return {status: result.rc === 0, details: result.jobOutput}
@@ -156,7 +156,7 @@ class Installation {
         return {status: false, details: `Error uploading yaml configuration: ${uploadYaml.details}`};
       }
       ProgressStore.set('initSecurity.uploadYaml', uploadYaml.status);
-      const script = `cd ${installationArgs.installationDir}/runtime/bin;\n./zwe init security -c ${installationArgs.installationDir}/zowe.yaml \n--allow-overwritten --update-config`;
+      const script = `cd ${installationArgs.installationDir}/runtime/bin;./zwe init security -c ${installationArgs.installationDir}/zowe.yaml --allow-overwritten --update-config`;
       const result = await new Script().run(connectionArgs, script);
       ProgressStore.set('initSecurity.success', result.rc === 0);
       return {status: result.rc === 0, details: result.jobOutput}
@@ -219,7 +219,7 @@ export class FTPInstallation extends Installation {
     //         easier but could fail on real system?
     const paxURL = `https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/${version}/zowe-${version}.pax`;
     const tempPath = path.join(app.getPath("temp"), "zowe.pax");
-    const result = await new FileTransfer().download_PAX(paxURL, tempPath);
+    const result = await new FileTransfer().downloadPax(paxURL, tempPath);
     return {status: true, details: ''} // REVIEW file transfer results
   }
 
@@ -238,20 +238,21 @@ export class FTPInstallation extends Installation {
     return result;
   }
 
+  // TODO: Is this necessary adding "/runtime" ? User already specifies /runtime directory - removes 8 chars from max limit. See Planning.tsx
   async unpax(connectionArgs: IIpcConnectionArgs, installDir: string) {
-    const script = `mkdir ${installDir}/runtime;\ncd ${installDir}/runtime;\npax -ppx -rf ../zowe.pax;\nrm ../zowe.pax`;
+    const script = `mkdir ${installDir}/runtime;cd ${installDir}/runtime;pax -ppx -rf ../zowe.pax;rm ../zowe.pax`;
     const result = await new Script().run(connectionArgs, script);
     return {status: result.rc === 0, details: result.jobOutput}
   }
 
   async install(connectionArgs: IIpcConnectionArgs, installDir: string) {
-    const script = `cd ${installDir}/runtime/bin;\n./zwe install -c ${installDir}/zowe.yaml --allow-overwritten`;
+    const script = `cd ${installDir}/runtime/bin;./zwe install -c ${installDir}/zowe.yaml --allow-overwritten`;
     const result = await new Script().run(connectionArgs, script);
     return {status: result.rc === 0, details: result.jobOutput}
   }
 
   async initMVS(connectionArgs: IIpcConnectionArgs, installDir: string) {
-    const script = `cd ${installDir}/runtime/bin;\n./zwe init mvs -c ${installDir}/zowe.yaml --allow-overwritten`;
+    const script = `cd ${installDir}/runtime/bin;./zwe init mvs -c ${installDir}/zowe.yaml --allow-overwritten`;
     const result = await new Script().run(connectionArgs, script);
     return {status: result.rc === 0, details: result.jobOutput}
   }

--- a/src/renderer/components/common/EditorDialog.tsx
+++ b/src/renderer/components/common/EditorDialog.tsx
@@ -39,13 +39,6 @@ const EditorDialog = ({contentType, isEditorVisible, toggleEditorVisibility, onC
   const [isSchemaValid, setIsSchemaValid] = useState(true);
   const [schemaError, setSchemaError] = useState('');
   const fileInputRef = useRef(null);
-  let initZoweConfig: any;
-
-
-  // if(contentType == 'yaml') {
-  //   initZoweConfig = getZoweConfig();
-  // }
-  
 
   useEffect(() => {
     setEditorVisible(isEditorVisible);
@@ -74,7 +67,6 @@ const EditorDialog = ({contentType, isEditorVisible, toggleEditorVisibility, onC
     }
 
     if(newCode && (newCode == "\n" || newCode == "")) {
-      // setZoweConfig("");
       return;
     }
 

--- a/src/renderer/components/stages/Planning.tsx
+++ b/src/renderer/components/stages/Planning.tsx
@@ -29,6 +29,10 @@ import { alertEmitter } from "../Header";
 import { Checkbox, FormControlLabel } from "@mui/material";
 import EditorDialog from "../common/EditorDialog";
 
+// TODO: Our current theoretical cap is 72 (possibly minus a couple for "\n", 70?) But we force more chars in InstallationHandler.tsx
+// This is all I want to manually test for now. Future work can min/max this harder
+const JCL_UNIX_SCRIPT_CHARS = 55;
+
 const serverSchema = {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "https://zowe.org/schemas/v2/server-common",
@@ -490,6 +494,7 @@ Please customize the job statement below to match your system requirements.
                 label="Run-time Directory (or installation location)"
                 variant="standard"
                 value={localYaml?.zowe?.runtimeDirectory || installationArgs.installationDir}
+                inputProps={{ maxLength: JCL_UNIX_SCRIPT_CHARS }}
                 onChange={(e) => {
                   dispatch(setInstallationArgs({...installationArgs, installationDir: e.target.value}));
                   setLocalYaml((prevYaml: { zowe: any; }) => ({
@@ -513,6 +518,7 @@ Please customize the job statement below to match your system requirements.
                 label="Workspace Directory"
                 variant="standard"
                 value={localYaml?.zowe?.workspaceDirectory ?? ''}
+                inputProps={{ maxLength: JCL_UNIX_SCRIPT_CHARS }}
                 onChange={(e) => {
                   dispatch(setInstallationArgs({...installationArgs, workspaceDir: e.target.value}));
                   setLocalYaml((prevYaml: { zowe: any; }) => ({
@@ -536,6 +542,7 @@ Please customize the job statement below to match your system requirements.
                 label="Log Directory"
                 variant="standard"
                 value={localYaml?.zowe?.logDirectory || installationArgs.logDir}
+                inputProps={{ maxLength: JCL_UNIX_SCRIPT_CHARS }}
                 onChange={(e) => {
                   dispatch(setInstallationArgs({...installationArgs, logDir: e.target.value}));
                   setLocalYaml((prevYaml: { zowe: any; }) => ({
@@ -559,6 +566,7 @@ Please customize the job statement below to match your system requirements.
                 label="Extensions Directory"
                 variant="standard"
                 value={localYaml?.zowe?.extensionDirectory || installationArgs.extensionDir}
+                inputProps={{ maxLength: JCL_UNIX_SCRIPT_CHARS }}
                 onChange={(e) => {
                   dispatch(setInstallationArgs({...installationArgs, extensionDir: e.target.value}));
                   setLocalYaml((prevYaml: { zowe: any; }) => ({

--- a/src/renderer/components/stages/installation/Installation.tsx
+++ b/src/renderer/components/stages/installation/Installation.tsx
@@ -198,7 +198,7 @@ const Installation = () => {
           <React.Fragment>
             <ProgressCard label={`Upload configuration file to ${installationArgs.installationDir}`} id="download-progress-card" status={installationProgress.uploadYaml}/>
             <ProgressCard label="Download convenience build pax locally" id="download-progress-card" status={installationProgress.download}/>
-            <ProgressCard label={`Upload to pax file to ${installationArgs.installationDir}`} id="upload-progress-card" status={installationProgress.upload}/>
+            <ProgressCard label={`Upload pax file to ${installationArgs.installationDir}`} id="upload-progress-card" status={installationProgress.upload}/>
             <ProgressCard label="Unpax installation files" id="unpax-progress-card" status={installationProgress.unpax}/>
             <ProgressCard label="Run installation script (zwe install)" id="install-progress-card" status={installationProgress.install}/>
             <ProgressCard label="Run MVS dataset initialization script (zwe init mvs)" id="install-progress-card" status={installationProgress.initMVS}/>

--- a/src/renderer/global.css
+++ b/src/renderer/global.css
@@ -128,6 +128,7 @@ a:hover {
   /* border-bottom: 1px solid #E0E0E0; */
   background-color: #E0E0E0;
   box-shadow: inset 0px 4px 4px 1px rgb(0 0 0 / 10%), rgb(0 0 0 / 20%) 0px 6px 7px -1px;
+  z-index: 999;
 }
 
 .action-card {

--- a/src/services/CheckENV.ts
+++ b/src/services/CheckENV.ts
@@ -10,15 +10,13 @@
 
 import {IIpcConnectionArgs, IJobResults} from "../types/interfaces";
 import {submitJcl} from "./SubmitJcl";
+import {startBPXBATCHAndShellSession} from "./utils";
 
 export class CheckENV {
 
   public async run(connectionArgs: IIpcConnectionArgs) {
     const jcl = `${connectionArgs.jobStatement}
-//SETPR2    EXEC PGM=BPXBATCH,REGION=0M
-//STDOUT DD SYSOUT=*
-//STDPARM      DD *
-sh set -x;
+${startBPXBATCHAndShellSession("ZNCHKNV")}
 echo $JAVA_HOME;
 echo $NODE_HOME;
 /* `

--- a/src/services/CheckJava.ts
+++ b/src/services/CheckJava.ts
@@ -10,16 +10,14 @@
 
 import {IIpcConnectionArgs, IJobResults} from "../types/interfaces";
 import {submitJcl} from "./SubmitJcl";
+import {startBPXBATCHAndShellSession} from "./utils";
 
 export class CheckJava {
 
   public async run(config: IIpcConnectionArgs, java: string) {
 
     const jcl = `${config.jobStatement}
-//SETPR2    EXEC PGM=BPXBATCH,REGION=0M
-//STDOUT DD SYSOUT=*
-//STDPARM      DD *
-sh set -x;
+${startBPXBATCHAndShellSession("ZNCHKJV")}
 ${java}/bin/java -version;
 echo "Script finished."
 /* `

--- a/src/services/CheckNode.ts
+++ b/src/services/CheckNode.ts
@@ -10,16 +10,14 @@
 
 import {IIpcConnectionArgs, IJobResults} from "../types/interfaces";
 import {submitJcl} from "./SubmitJcl";
+import { startBPXBATCHAndShellSession } from "./utils";
 
 export class CheckNode {
 
   public async run(config: IIpcConnectionArgs, node: string) {
 
     const jcl = `${config.jobStatement}
-//SETPR4    EXEC PGM=BPXBATCH,REGION=0M
-//STDOUT DD SYSOUT=*
-//STDPARM      DD *
-sh set -x;
+${startBPXBATCHAndShellSession("ZNCKNOD")}
 ${node}/bin/node -v;
 echo "Script finished."
 /* `

--- a/src/services/CheckSpace.ts
+++ b/src/services/CheckSpace.ts
@@ -10,16 +10,14 @@
 
 import {IIpcConnectionArgs, IJobResults} from "../types/interfaces";
 import {submitJcl} from "./SubmitJcl";
+import { startBPXBATCHAndShellSession } from "./utils";
 
 export class CheckSpace {
 
   public async run(config: IIpcConnectionArgs, dir: string) {
 
     const jcl = `${config.jobStatement}
-//SETPR6    EXEC PGM=BPXBATCH,REGION=0M
-//STDOUT DD SYSOUT=*
-//STDPARM      DD *
-sh set -x;
+${startBPXBATCHAndShellSession("ZNCHKSP")}
 echo "SPACE in MB";
 df -m ${dir};
 echo "Script finished."

--- a/src/services/FileTransfer.ts
+++ b/src/services/FileTransfer.ts
@@ -29,7 +29,7 @@ export class FileTransfer {
     return downFile.toString();
   }
 
-  public async download_PAX(file: any, fullPath: string) {
+  public async downloadPax(file: any, fullPath: string) {
     return new Promise(resolve => {
       const saveFile: NodeJS.WritableStream = fs.createWriteStream(fullPath);
       https.get(file, function (response: IncomingMessage) {

--- a/src/services/RunScript.ts
+++ b/src/services/RunScript.ts
@@ -10,7 +10,7 @@
 
 import {IIpcConnectionArgs, IJobResults} from "../types/interfaces";
 import {submitJcl} from "./SubmitJcl";
-import {splitUnixScriptByNumOfChars, startBPXBATCHAndShellSession} from "./utils";
+import {parseUnixScriptByNumOfChars, startBPXBATCHAndShellSession} from "./utils";
 
 export class Script {
 
@@ -19,7 +19,7 @@ export class Script {
     // TODO: Shouldn't we change ";" to "&&" to stop on first fail instead of keep going?
     const jcl = `${config.jobStatement}
 ${startBPXBATCHAndShellSession("ZNSCRPT")}
-${splitUnixScriptByNumOfChars(script)};
+${parseUnixScriptByNumOfChars(script)};
 echo "Script finished."
 /* `
     console.log(`JOB: ${jcl}`)

--- a/src/services/RunScript.ts
+++ b/src/services/RunScript.ts
@@ -10,18 +10,16 @@
 
 import {IIpcConnectionArgs, IJobResults} from "../types/interfaces";
 import {submitJcl} from "./SubmitJcl";
+import {splitUnixScriptByNumOfChars, startBPXBATCHAndShellSession} from "./utils";
 
 export class Script {
 
   public async run(config: IIpcConnectionArgs, script: string) {
 
+    // TODO: Shouldn't we change ";" to "&&" to stop on first fail instead of keep going?
     const jcl = `${config.jobStatement}
-//RUNSCRP EXEC PGM=BPXBATCH,REGION=0M
-//STDOUT DD SYSOUT=*
-//STDERR DD SYSOUT=*
-//STDPARM  DD *
-sh set -x;
-${script};
+${startBPXBATCHAndShellSession("ZNSCRPT")}
+${splitUnixScriptByNumOfChars(script)};
 echo "Script finished."
 /* `
     console.log(`JOB: ${jcl}`)

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -52,18 +52,18 @@ export async function makeDir(config: IIpcConnectionArgs, dir: string): Promise<
   }
 }
 
-export function splitUnixScriptByNumOfChars(script: string, charCount: number = JCL_UNIX_SCRIPT_CHARS): string {
+// This adds a "\n" inside Unix commands separated by ";"
+export function parseUnixScriptByNumOfChars(script: string, charCount: number = JCL_UNIX_SCRIPT_CHARS): string {
   const parts: string[] = [];
   let currentPart = '';
   let counter = 0;
 
   for (let i = 0; i < script.length; i++) {
       if (counter >= charCount) {
-          // Check if we've exceeded the character limit
           const lastSpaceIndex = currentPart.lastIndexOf(' ');
 
           if (lastSpaceIndex !== -1) {
-              // If there's a space within the character limit, backtrack to the last space
+              // If there's a space within the character limit, backtrack to the last encountered space
               const backtrackedPart = currentPart.substring(0, lastSpaceIndex);
               parts.push(backtrackedPart);
               currentPart = currentPart.substring(lastSpaceIndex + 1);

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -13,6 +13,10 @@ import Header from "../renderer/components/Header"
 import { AlertColor } from "@mui/material/Alert";
 import zos from 'zos-node-accessor';
 
+export const JCL_UNIX_SCRIPT_CHARS = 70;
+
+export const JCL_JOBNAME_DEFAULT = "ZENJOB";
+
 export async function connectFTPServer(config: IIpcConnectionArgs): Promise<any> {
 
   const client = new zos();
@@ -46,4 +50,42 @@ export async function makeDir(config: IIpcConnectionArgs, dir: string): Promise<
   } finally {
     client.close();
   }
+}
+
+export function splitUnixScriptByNumOfChars(script: string, charCount: number = JCL_UNIX_SCRIPT_CHARS): string {
+  const parts: string[] = [];
+  let currentPart = '';
+  let counter = 0;
+
+  for (let i = 0; i < script.length; i++) {
+      if (counter >= charCount) {
+          // Check if we've exceeded the character limit
+          const lastSpaceIndex = currentPart.lastIndexOf(' ');
+
+          if (lastSpaceIndex !== -1) {
+              // If there's a space within the character limit, backtrack to the last space
+              const backtrackedPart = currentPart.substring(0, lastSpaceIndex);
+              parts.push(backtrackedPart);
+              currentPart = currentPart.substring(lastSpaceIndex + 1);
+          }
+          if (currentPart.length > 0) {
+              // Add the current part and reset the counter
+              parts.push('\n');
+              counter = 0;
+          }
+      }
+      currentPart += script[i];
+      counter++;
+  }
+  if (currentPart.length > 0) {
+      parts.push(currentPart);
+  }
+  return parts.join('');
+}
+
+export function startBPXBATCHAndShellSession(jobName: string = JCL_JOBNAME_DEFAULT): string {
+  return `//${jobName}    EXEC PGM=BPXBATCH,REGION=0M
+//STDOUT DD SYSOUT=*
+//STDPARM      DD *
+sh set -x;`;
 }

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -52,7 +52,7 @@ export async function makeDir(config: IIpcConnectionArgs, dir: string): Promise<
   }
 }
 
-// This adds a "\n" inside Unix commands separated by ";"
+// This adds a "\n" inside Unix commands separated by ";" if char limit reached
 export function parseUnixScriptByNumOfChars(script: string, charCount: number = JCL_UNIX_SCRIPT_CHARS): string {
   const parts: string[] = [];
   let currentPart = '';


### PR DESCRIPTION
This adds:
- max char limit for Unix directories (UI side)
- removes a little code duplication in sending JCL logic
- better string separation for JCL scripts (automatically line breaks when a long command becomes too long - this removes the need for adding `\n` to our commands, you can just separate each command with as usual `;` )

So commands like this now work:

      '+ cd /u/ts6321/zowe-zen-install/runnntimeeeelongg/runtime/bin \r\n' +
      '+ ./zwe init apfauth -c /u/ts6321/zowe-zen-install/runnntimeeeelongg/zowe.yaml --allow-overwritten --update-config \r\n' +
      '-------------------------------------------------------------------------------\r\n' +
      '>> APF authorize load libraries\r\n' +
      'APF authorize TS6321.ZOWE6.SZWEAUTH\r\n' +
      'APF authorize TS6321.ZOWE6.CUST.ZOWESAPL\r\n' +
      '>> Zowe load libraries are APF authorized successfully.\r\n' +
      
  instead of getting pooped