### PR TITLE
Remove python step in mac builder

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -80,7 +80,6 @@ jobs:
         uses: actions/checkout@v3
       - name: '[prep 4] Install'
         run: |
-          python3 -m pip install setuptools
           npm install     
       - name: '[prep 5] Package'
         run: |


### PR DESCRIPTION
Build currently complains about python3 install of setuptools (which was added to fix a previous bug)