### PR TITLE
Fix macos build

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -82,6 +82,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.11.4'
+      - name: 'setup appdmg'
+        run: |
+          python3 -m pip install setuptools
+          npm install -g appdmg@0.6.6
       - name: '[prep 5] Install'
         run: |
           npm install     

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -78,14 +78,17 @@ jobs:
           node-version: 18
       - name: '[Prep 3] Checkout'
         uses: actions/checkout@v3
-      - name: '[prep 4] Install'
+      - name: '[Prep 4] Install Python 3.11.4 for appdmg compatibility'
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11.4'
+      - name: '[prep 5] Install'
         run: |
-          python3 -m pip install setuptools
           npm install     
-      - name: '[prep 5] Package'
+      - name: '[prep 6] Package'
         run: |
           npm run make  
-      - name: '[prep 6] Publish'
+      - name: '[prep 7] Publish'
         uses: zowe-actions/zlux-builds/zen/publish@v2.x/main
         with: 
           os: macos

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -78,16 +78,13 @@ jobs:
           node-version: 18
       - name: '[Prep 3] Checkout'
         uses: actions/checkout@v3
-      - name: '[Prep 4] Install Python 3.12 for appdmg'
+      - name: '[Prep 4] Install Python 3.12 for npm appdmg'
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - name: 'setup appdmg'
-        run: |
-          python3 -m pip install setuptools
-          npm install -g appdmg@0.6.6
       - name: '[prep 5] Install'
         run: |
+          python3 -m pip install setuptools
           npm install     
       - name: '[prep 6] Package'
         run: |

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -78,10 +78,10 @@ jobs:
           node-version: 18
       - name: '[Prep 3] Checkout'
         uses: actions/checkout@v3
-      - name: '[Prep 4] Install Python 3.11.4 for appdmg compatibility'
-        uses: actions/setup-python@v4
+      - name: '[Prep 4] Install Python 3.12 for appdmg'
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.11.4'
+          python-version: '3.12'
       - name: 'setup appdmg'
         run: |
           python3 -m pip install setuptools
@@ -93,7 +93,7 @@ jobs:
         run: |
           npm run make  
       - name: '[prep 7] Publish'
-        uses: zowe-actions/zlux-builds/zen/publish@v2.x/main
+        uses: zowe-actions/zlux-builds/zen/publish@arm64-osx
         with: 
           os: macos
           

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -90,7 +90,7 @@ jobs:
         run: |
           npm run make  
       - name: '[prep 7] Publish'
-        uses: zowe-actions/zlux-builds/zen/publish@arm64-osx
+        uses: zowe-actions/zlux-builds/zen/publish@v2.x/main
         with: 
           os: macos
           


### PR DESCRIPTION
Macos isnt building because of 
1) appdmg failing to install which is due to python.
2) the github builder now builds macos in arm64 edition instead of x64. that's fine, but it needs a workflow update.