### PR TITLE
Add logging to file + small release changes

### DIFF
--- a/Developer.md
+++ b/Developer.md
@@ -1,4 +1,4 @@
-# ZEN - Zowe Enterprise Necessity
+# ZEN - Zowe Server Install Wizard
 
 ### Introduction
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Node version 18.12 or higher is required.
 
 ### Developing
 
-Note: `npm run start` may succeed without errors, but `npm run make` will not. It is always advised to run `npm run make` after writing new code, or using the build automation to view errors
+Note: `npm run start` may succeed without errors, but `npm run make` may not. It is always advised to run `npm run make` after writing new code, or using the build automation to view errors
 
 Run `npm install` to install dependencies 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ZEN - Zowe Enterprise Necessity
+# ZEN - Zowe Server Install Wizard
 
-Zowe Enterprise Necessity is an Electron-based tool that provides a simpler UI to install and configure Zowe
+Zowe Server Install Wizard is an Electron-based tool that provides a simpler UI to install and configure Zowe
 
 The application is in the development stage and has limited functionality so far. It is able to connect to the mainframe using the [zos-node-accessor](https://github.com/IBM/zos-node-accessor) module, perform some basic environment validations, download the Zowe convenience build, and run `zwe install` command by submitting JES jobs. [Here](https://github.com/zowe/zen/issues/1) is a brief description with screenshots.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@types/flat": "^5.0.2",
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
+        "electron-log": "^5.1.5",
         "electron-squirrel-startup": "^1.0.0",
         "electron-store": "^8.1.0",
         "flat": "^5.0.2",
@@ -5246,6 +5247,14 @@
       "optional": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/electron-log": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.1.5.tgz",
+      "integrity": "sha512-vuq10faUAxRbILgQx7yHoMObKZDEfj7hMSZrJPsVrDNeCpV/HN11dU7QuY4UDUe055pzBxhSCB3m0+6D3Aktjw==",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/electron-packager": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "zowe-enterprise-necessity",
+  "name": "zowe-install-wizard",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "zowe-enterprise-necessity",
+      "name": "zowe-install-wizard",
       "version": "1.0.0",
       "license": "EPL 2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "zowe-enterprise-necessity",
+  "name": "zowe-install-wizard",
   "author": "Zowe",
-  "description": "Zowe Enterprise Necessity",
-  "productName": "zowe-enterprise-necessity",
+  "description": "Zowe Server Install Wizard",
+  "productName": "zowe-install-wizard",
   "version": "1.0.0",
   "main": ".webpack/main",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@types/flat": "^5.0.2",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
+    "electron-log": "^5.1.5",
     "electron-squirrel-startup": "^1.0.0",
     "electron-store": "^8.1.0",
     "flat": "^5.0.2",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -19,12 +19,18 @@ import { ProgressStore } from "../storage/ProgressStore";
 import { checkDirExists } from '../services/ServiceUtils';
 import { ConfigurationStore } from '../storage/ConfigurationStore';
 import { EditorStore } from '../storage/EditorStore';
+import { log, warn, error, info } from 'electron-log/main';
 
 declare const MAIN_WINDOW_WEBPACK_ENTRY: string;
 declare const MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY: string;
 
 const connectionActions = new ConnectionActions();
 const installActions = new InstallActions();
+
+console.log = log;
+console.warn = warn;
+console.error = error;
+console.info = info;
 
 // REVIEW: electron-squirrel-startup, review the necessity of it, package will have an operation viloation as it is 7 years old. 
 // if (require('electron-squirrel-startup')) { // ?

--- a/src/renderer/components/Header.tsx
+++ b/src/renderer/components/Header.tsx
@@ -84,7 +84,7 @@ export default function Header() {
         <AppBar position="static">
           <Toolbar sx={{boxShadow: '0px 2px 4px 3px rgb(0 0 0 / 25%)', minHeight: '60px !important'}}>
             <Typography style={{ textAlign: 'right' }} variant="h6" component="div" sx={{ flexGrow: 1 }}>
-              Zowe Enterprise Necessity
+              Zowe Server Install Wizard
             </Typography>
             {alertData.show && (
               <><Alert style={{ position: 'absolute' }} severity={alertData.severity}>{alertData.message}

--- a/src/renderer/components/stages/Certificates.tsx
+++ b/src/renderer/components/stages/Certificates.tsx
@@ -253,7 +253,7 @@ const Certificates = () => {
     <div id="container-box-id">
       <Box sx={{ position:'absolute', bottom: '1px', display: 'flex', flexDirection: 'row', p: 1, justifyContent: 'flex-start', [theme.breakpoints.down('lg')]: {flexDirection: 'column',alignItems: 'flex-start'}}}>
         <Button variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility(TYPE_YAML)}>View/Edit Yaml</Button>
-        <Button variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility(TYPE_JCL)}>View/Submit Job</Button>
+        {/* <Button variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility(TYPE_JCL)}>View/Submit Job</Button> */}
         <Button variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility(TYPE_OUTPUT)}>View Job Output</Button>
       </Box>
       <ContainerCard title="Certificates" description="Configure Zowe Certificates."> 

--- a/src/renderer/components/stages/InitApfAuth.tsx
+++ b/src/renderer/components/stages/InitApfAuth.tsx
@@ -287,7 +287,7 @@ const InitApfAuth = () => {
     <div id="container-box-id">
       <Box sx={{ position:'absolute', bottom: '1px', display: 'flex', flexDirection: 'row', p: 1, justifyContent: 'flex-start', [theme.breakpoints.down('lg')]: {flexDirection: 'column',alignItems: 'flex-start'}}}>
         <Button variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility("yaml")}>View/Edit Yaml</Button>
-        <Button variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility("jcl")}>View/Submit Job</Button>
+        {/* <Button variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility("jcl")}>View/Submit Job</Button> */}
         <Button variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility("output")}>View Job Output</Button>
       </Box>
       <ContainerCard title="APF Authorize Load Libraries" description="Run the `zwe init apfauth` command to APF authorize load libraries.">

--- a/src/renderer/components/stages/LaunchConfig.tsx
+++ b/src/renderer/components/stages/LaunchConfig.tsx
@@ -513,7 +513,7 @@ const LaunchConfig = () => {
     <div id="container-box-id">
       <Box sx={{ position:'absolute', bottom: '1px', display: 'flex', flexDirection: 'row', p: 1, justifyContent: 'flex-start', [theme.breakpoints.down('lg')]: {flexDirection: 'column',alignItems: 'flex-start'}}}>
         <Button variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility(TYPE_YAML)}>View/Edit Yaml</Button>
-        <Button variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility(TYPE_JCL)}>View/Submit Job</Button>
+        {/* <Button variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility(TYPE_JCL)}>View/Submit Job</Button> */}
         <Button variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility(TYPE_OUTPUT)}>View Job Output</Button>
       </Box>
       <ContainerCard title="Configuration" description="Basic zowe.yaml configurations."> 

--- a/src/renderer/components/stages/Networking.tsx
+++ b/src/renderer/components/stages/Networking.tsx
@@ -722,7 +722,7 @@ const Networking = () => {
     yaml && schema && <div id="container-box-id">
       <Box sx={{ position:'absolute', bottom: '1px', display: 'flex', flexDirection: 'row', p: 1, justifyContent: 'flex-start', [theme.breakpoints.down('lg')]: {flexDirection: 'column',alignItems: 'flex-start'}}}>
         <Button key="yaml" variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility(TYPE_YAML)}>View/Edit Yaml</Button>
-        <Button key="jcl" variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility(TYPE_JCL)}>View/Submit Job</Button>
+        {/* <Button key="jcl" variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility(TYPE_JCL)}>View/Submit Job</Button> */}
         <Button key="job" variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility(TYPE_OUTPUT)}>View Job Output</Button>
       </Box>
       <ContainerCard title="Networking" description="Zowe networking configurations."> 

--- a/src/renderer/components/stages/ReviewInstallation.tsx
+++ b/src/renderer/components/stages/ReviewInstallation.tsx
@@ -107,7 +107,7 @@ const ReviewInstallation = () => {
     <div>
       <Box sx={{ position:'absolute', bottom: '1px', display: 'flex', flexDirection: 'row', p: 1, justifyContent: 'flex-start', [theme.breakpoints.down('lg')]: {flexDirection: 'column',alignItems: 'flex-start'}}}>
         <Button variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility(TYPE_YAML)}>View Yaml</Button>
-        <Button variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility(TYPE_JCL)}>View/Submit Job</Button>
+        {/* <Button variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility(TYPE_JCL)}>View/Submit Job</Button> */}
         <Button variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility(TYPE_OUTPUT)}>View Job Output</Button>
       </Box>
     <ContainerCard title="Review Installation" description="Review all steps before clicking Finish Installation. Visit a previous step to change it.">

--- a/src/renderer/components/stages/Security.tsx
+++ b/src/renderer/components/stages/Security.tsx
@@ -277,7 +277,7 @@ const Security = () => {
     <div id="container-box-id">
       <Box sx={{ position:'absolute', bottom: '1px', display: 'flex', flexDirection: 'row', p: 1, justifyContent: 'flex-start', [theme.breakpoints.down('lg')]: {flexDirection: 'column',alignItems: 'flex-start'}}}>
         <Button variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility("yaml")}>View/Edit Yaml</Button>
-        <Button variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility("jcl")}>View/Submit Job</Button>
+        {/* <Button variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility("jcl")}>View/Submit Job</Button> */}
         <Button variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility("output")}>View Job Output</Button>
       </Box>
       <ContainerCard title="Security" description="Configure Zowe Security.">

--- a/src/renderer/components/stages/Vsam.tsx
+++ b/src/renderer/components/stages/Vsam.tsx
@@ -297,7 +297,7 @@ const Vsam = () => {
     <div id="container-box-id">
       <Box sx={{ position:'absolute', bottom: '1px', display: 'flex', flexDirection: 'row', p: 1, justifyContent: 'flex-start', [theme.breakpoints.down('lg')]: {flexDirection: 'column',alignItems: 'flex-start'}}}>
         <Button variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility("yaml")}>View/Edit Yaml</Button>
-        <Button variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility("jcl")}>View/Submit Job</Button>
+        {/* <Button variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility("jcl")}>View/Submit Job</Button> */}
         <Button variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility("output")}>View Job Output</Button>
       </Box>
       <ContainerCard title="Vsam" description="Configure Zowe Vsam.">

--- a/src/renderer/components/stages/installation/Installation.tsx
+++ b/src/renderer/components/stages/installation/Installation.tsx
@@ -354,7 +354,7 @@ const Installation = () => {
     <div id="container-box-id">
       <Box sx={{ position:'absolute', bottom: '1px', display: 'flex', flexDirection: 'row', p: 1, justifyContent: 'flex-start', [theme.breakpoints.down('lg')]: {flexDirection: 'column',alignItems: 'flex-start'}}}>
         <Button variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility(TYPE_YAML)}>View/Edit Yaml</Button>
-        <Button variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility(TYPE_JCL)}>View/Submit Job</Button>
+        {/* <Button variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility(TYPE_JCL)}>View/Submit Job</Button> */}
         <Button variant="outlined" sx={{ textTransform: 'none', mr: 1 }} onClick={() => toggleEditorVisibility(TYPE_OUTPUT)}>View Job Output</Button>
       </Box>
       <ContainerCard title="Installation" description="Provide installation details."> 

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <title>Zowe Enterprise Necessity</title>
+    <title>Zowe Server Install Wizard</title>
   </head>
   <body>
     <div id="zen-root-container"></div>


### PR DESCRIPTION
By default, it writes logs to the following locations:

on Linux: ~/.config/{app name}/logs/main.log
on macOS: ~/Library/Logs/{app name}/main.log
on Windows: %USERPROFILE%\AppData\Roaming\{app name}\logs\main.log

Adding logging to file, because UI doesn't always correctly displays error content in full. Not all console errors can be tested/parsed and visualized so for now, adding logging