### PR TITLE
Replacing cat command output parsing with file downloading

### DIFF
--- a/src/actions/InstallationHandler.ts
+++ b/src/actions/InstallationHandler.ts
@@ -138,118 +138,95 @@ class Installation {
       let yamlObj
       let zoweRuntimePath = installationArgs.installationType === "smpe" ? installationArgs.installationDir : installationArgs.installationDir + "/runtime";
       let readPaxYamlAndSchema = await this.readExampleYamlAndSchema(connectionArgs, zoweRuntimePath);
-      let parsedSchema = false, parsedYaml = false;
-      if(readPaxYamlAndSchema.details.yaml){
-        const parseExampleYamlFromPax = function(catPath: string){
-          const jobOutputSplit = JSON.stringify(readPaxYamlAndSchema.details.yaml).split(`cat ${catPath}\\r\\n`)
-          if(jobOutputSplit[1]){
-            const trimmedYamlSchema = jobOutputSplit[1].split(`+ echo 'Script finished.'`)[0].split(`Script finished.`);
-            // console.log("\n\n *** trimmedYamlSchema[0]: ", trimmedYamlSchema[0].replaceAll(`\\r\\n`, `\r\n`).replaceAll(`\\"`, `"`));
-            return trimmedYamlSchema[0].replaceAll(`\\r\\n`, `\r\n`).replaceAll(`\\"`, `"`);
+
+      const yamlFromPax = readPaxYamlAndSchema.details.yaml;
+      if (yamlFromPax) {
+        try {
+          yamlObj = parse(yamlFromPax);
+          if (currentConfig) {
+            // console.log("current config:", JSON.stringify(currentConfig));
+            // console.log("yamlObj: ", JSON.stringify(yamlObj));
+            yamlObj = {...yamlObj, ...currentConfig}
+            // console.log("merged yamlObj: ", JSON.stringify(yamlObj));
           }
-          return "";
-        }
-        const yamlFromPax = parseExampleYamlFromPax(`${zoweRuntimePath}/example-zowe.yaml`);
-        if(yamlFromPax){
-          try {
-            yamlObj = parse(yamlFromPax);
-            if (currentConfig) {
-              // console.log("current config:", JSON.stringify(currentConfig));
-              // console.log("yamlObj: ", JSON.stringify(yamlObj));
-              yamlObj = {...currentConfig, ...yamlObj}
-              // console.log("merged yamlObj: ", JSON.stringify(yamlObj));
-            }
-            if (yamlObj.zowe.runtimeDirectory === undefined && installationArgs.installationDir) {
-              yamlObj.zowe.runtimeDirectory = installationArgs.installationDir;
-            }
-            if (yamlObj.zowe.workspaceDirectory === undefined && installationArgs.workspaceDir) {
-              yamlObj.zowe.workspaceDirectory = installationArgs.workspaceDir;
-            }
-            if (yamlObj.zowe.logDirectory === undefined && installationArgs.logDir) {
-              yamlObj.zowe.logDirectory = installationArgs.logDir;
-            }
-            if (yamlObj.zowe.extensionDirectory === undefined && installationArgs.extensionDir) {
-              yamlObj.zowe.extensionDirectory = installationArgs.extensionDir;
-            }
-            if (yamlObj.zowe.rbacProfileIdentifier === undefined && installationArgs.rbacProfile) {
-              yamlObj.zowe.rbacProfileIdentifier = installationArgs.rbacProfile;
-            }
-            if (yamlObj.zowe.job.name === undefined && installationArgs.jobName) {
-              yamlObj.zowe.job.name = installationArgs.jobName;
-            }
-            if (yamlObj.zowe.job.prefix === undefined && installationArgs.jobPrefix) {
-              yamlObj.zowe.job.prefix = installationArgs.jobPrefix;
-            }
-            if (yamlObj.zowe.cookieIdentifier === undefined && installationArgs.cookieId) {
-              yamlObj.zowe.cookieIdentifier = installationArgs.cookieId;
-            }
-            if (yamlObj.java.home === undefined && installationArgs.javaHome) {
-              yamlObj.java.home = installationArgs.javaHome;
-            }
-            if (yamlObj.node.home === undefined && installationArgs.nodeHome) {
-              yamlObj.node.home = installationArgs.nodeHome;
-            }
-            if (yamlObj.zOSMF.host === undefined && installationArgs.zosmfHost) {
-              yamlObj.zOSMF.host = installationArgs.zosmfHost;
-            }
-            if (yamlObj.zOSMF.port === undefined && installationArgs.zosmfPort) {
-              yamlObj.zOSMF.port = installationArgs.zosmfPort;
-            }
-            if (yamlObj.zOSMF.applId === undefined && installationArgs.zosmfApplId) {
-              yamlObj.zOSMF.applId = installationArgs.zosmfApplId;
-            }
-            if (zoweConfig) {
-              yamlObj = {...yamlObj, ...zoweConfig};
-            }
-            // console.log('Setting merged yaml:', JSON.stringify(yamlObj));
-            ConfigurationStore.setConfig(yamlObj);
-            ProgressStore.set('downloadUnpax.getExampleYaml', true);
-          } catch(e) {
-            console.log('error parsing example-zowe.yaml:', e);
-            ProgressStore.set('downloadUnpax.getExampleYaml', false);
+          if (yamlObj.zowe.runtimeDirectory === undefined && installationArgs.installationDir) {
+            yamlObj.zowe.runtimeDirectory = installationArgs.installationDir;
           }
-        } else {
-          console.log("no yaml found from pax");
+          if (yamlObj.zowe.workspaceDirectory === undefined && installationArgs.workspaceDir) {
+            yamlObj.zowe.workspaceDirectory = installationArgs.workspaceDir;
+          }
+          if (yamlObj.zowe.logDirectory === undefined && installationArgs.logDir) {
+            yamlObj.zowe.logDirectory = installationArgs.logDir;
+          }
+          if (yamlObj.zowe.extensionDirectory === undefined && installationArgs.extensionDir) {
+            yamlObj.zowe.extensionDirectory = installationArgs.extensionDir;
+          }
+          if (yamlObj.zowe.rbacProfileIdentifier === undefined && installationArgs.rbacProfile) {
+            yamlObj.zowe.rbacProfileIdentifier = installationArgs.rbacProfile;
+          }
+          if (yamlObj.zowe.job.name === undefined && installationArgs.jobName) {
+            yamlObj.zowe.job.name = installationArgs.jobName;
+          }
+          if (yamlObj.zowe.job.prefix === undefined && installationArgs.jobPrefix) {
+            yamlObj.zowe.job.prefix = installationArgs.jobPrefix;
+          }
+          if (yamlObj.zowe.cookieIdentifier === undefined && installationArgs.cookieId) {
+            yamlObj.zowe.cookieIdentifier = installationArgs.cookieId;
+          }
+          if (yamlObj.java.home === undefined && installationArgs.javaHome) {
+            yamlObj.java.home = installationArgs.javaHome;
+          }
+          if (yamlObj.node.home === undefined && installationArgs.nodeHome) {
+            yamlObj.node.home = installationArgs.nodeHome;
+          }
+          if (yamlObj.zOSMF.host === undefined && installationArgs.zosmfHost) {
+            yamlObj.zOSMF.host = installationArgs.zosmfHost;
+          }
+          if (yamlObj.zOSMF.port === undefined && installationArgs.zosmfPort) {
+            yamlObj.zOSMF.port = installationArgs.zosmfPort;
+          }
+          if (yamlObj.zOSMF.applId === undefined && installationArgs.zosmfApplId) {
+            yamlObj.zOSMF.applId = installationArgs.zosmfApplId;
+          }
+          if (zoweConfig) {
+            yamlObj = {...yamlObj, ...zoweConfig};
+          }
+          // console.log('Setting merged yaml:', JSON.stringify(yamlObj));
+          ConfigurationStore.setConfig(yamlObj);
+          ProgressStore.set('downloadUnpax.getExampleYaml', true);
+        } catch(e) {
+          console.log('error parsing example-zowe.yaml:', e);
           ProgressStore.set('downloadUnpax.getExampleYaml', false);
         }
-
-        //No reason not to always set schema to latest if user is re-running installation
-        if(readPaxYamlAndSchema.details.yamlSchema && readPaxYamlAndSchema.details.serverCommon){
-          const parseSchemaFromPax = function(inputString: string, catPath: string){
-            const jobOutputSplit = inputString.split(`cat ${catPath}\\r\\n`)
-            if(jobOutputSplit[1]){
-              const trimmedYamlSchema = jobOutputSplit[1].split(`Script finished.`)[0].split(`Script finished.`);
-              return trimmedYamlSchema[0].replaceAll(`\\r\\n`, `\r\n`).replaceAll(`\\"`, `"`).replaceAll(`\\\\"`, `\\"`);
-            }
-            return "";
-          }
-          try {
-            let yamlSchema = JSON.parse(parseSchemaFromPax(JSON.stringify(readPaxYamlAndSchema.details.yamlSchema), `${zoweRuntimePath}/schemas/zowe-yaml-schema.json`));
-            const serverCommon = JSON.parse(parseSchemaFromPax(JSON.stringify(readPaxYamlAndSchema.details.serverCommon), `${zoweRuntimePath}/schemas/server-common.json`));
-            // console.log('yaml schema:', parseSchemas(JSON.stringify(readPaxYamlAndSchema.details.yamlSchema), `${zoweRuntimePath}/schemas/zowe-yaml-schema.json`));
-            // console.log('server common', parseSchemas(JSON.stringify(readPaxYamlAndSchema.details.serverCommon), `${zoweRuntimePath}/schemas/server-common.json`));
-            if(yamlSchema && serverCommon){
-              // FIXME: Link schema by $ref properly - https://jsonforms.io/docs/ref-resolving
-              // Without these, AJV does not properly find $refs in the schema and therefore validation cannot occur
-              yamlSchema.properties.zowe.properties.setup.properties.dataset.properties.parmlibMembers.properties.zis = serverCommon.$defs.datasetMember;
-              yamlSchema.properties.zowe.properties.setup.properties.certificate.properties.pkcs12.properties.directory = serverCommon.$defs.path;
-              yamlSchema.$id = serverCommon.$id;
-              if(yamlSchema.$defs?.networkSettings?.properties?.server?.properties?.listenAddresses?.items){
-                delete yamlSchema.$defs?.networkSettings?.properties?.server?.properties?.listenAddresses?.items?.ref;
-                yamlSchema.$defs.networkSettings.properties.server.properties.listenAddresses.items = serverCommon.$defs.ipv4
-              }
-              // console.log('Setting schema from runtime dir:', JSON.stringify(yamlSchema));
-              ConfigurationStore.setSchema(yamlSchema);
-              ProgressStore.set('downloadUnpax.getSchemas', true);
-            }
-          } catch (e) {
-            console.log('error setting schema from pax:', e);
-            ProgressStore.set('downloadUnpax.getSchemas', false);
-          }
-        }
-        
+      } else {
+        console.log("no yaml found from pax");
+        ProgressStore.set('downloadUnpax.getExampleYaml', false);
       }
 
+      //No reason not to always set schema to latest if user is re-running installation
+      if (readPaxYamlAndSchema.details.yamlSchema && readPaxYamlAndSchema.details.serverCommon) {
+        try {
+          const yamlSchema = JSON.parse(readPaxYamlAndSchema.details.yamlSchema);
+          const serverCommon = JSON.parse(readPaxYamlAndSchema.details.serverCommon);
+          if (yamlSchema && serverCommon) {
+            // FIXME: Link schema by $ref properly - https://jsonforms.io/docs/ref-resolving
+            // Without these, AJV does not properly find $refs in the schema and therefore validation cannot occur
+            yamlSchema.properties.zowe.properties.setup.properties.dataset.properties.parmlibMembers.properties.zis = serverCommon.$defs.datasetMember;
+            yamlSchema.properties.zowe.properties.setup.properties.certificate.properties.pkcs12.properties.directory = serverCommon.$defs.path;
+            yamlSchema.$id = serverCommon.$id;
+            if (yamlSchema.$defs?.networkSettings?.properties?.server?.properties?.listenAddresses?.items) {
+              delete yamlSchema.$defs?.networkSettings?.properties?.server?.properties?.listenAddresses?.items?.ref;
+              yamlSchema.$defs.networkSettings.properties.server.properties.listenAddresses.items = serverCommon.$defs.ipv4
+            }
+            // console.log('Setting schema from runtime dir:', JSON.stringify(yamlSchema));
+            ConfigurationStore.setSchema(yamlSchema);
+            ProgressStore.set('downloadUnpax.getSchemas', true);
+          }
+        } catch (e) {
+          console.log('error setting schema from pax:', e);
+          ProgressStore.set('downloadUnpax.getSchemas', false);
+        }
+      }
       return {status: download.status && uploadYaml.status && upload.status && unpax.status, details: {message: 'Zowe unpax successful.', mergedYaml: yamlObj}};
     } catch (error) {
       return {status: false, details: error.message};
@@ -578,13 +555,17 @@ export class FTPInstallation extends Installation {
   }
 
   async readExampleYamlAndSchema(connectionArgs: IIpcConnectionArgs, installDir: string){
-    const catYaml = `cat ${installDir}/example-zowe.yaml`;
-    const yamlResult = await new Script().run(connectionArgs, catYaml);
-    const catYamlSchema = `cat ${installDir}/schemas/zowe-yaml-schema.json`;
-    const yamlSchemaResult = await new Script().run(connectionArgs, catYamlSchema);
-    const catCommonSchema = `cat ${installDir}/schemas/server-common.json`;
-    const commonSchemaResult = await new Script().run(connectionArgs, catCommonSchema);
-    return {status: yamlResult.rc === 0 && yamlSchemaResult.rc == 0 && commonSchemaResult.rc == 0, details: {yaml: yamlResult.jobOutput, yamlSchema: yamlSchemaResult.jobOutput, serverCommon: commonSchemaResult.jobOutput}}
+    try {    
+      const yamlPath = `${installDir}/example-zowe.yaml`;
+      const yaml = await new FileTransfer().download(connectionArgs, yamlPath, DataType.ASCII);
+      const yamlSchemaPath = `${installDir}/schemas/zowe-yaml-schema.json`;
+      const yamlSchema = await new FileTransfer().download(connectionArgs, yamlSchemaPath, DataType.ASCII);
+      const serverCommonPath = `${installDir}/schemas/server-common.json`;
+      const serverCommon = await new FileTransfer().download(connectionArgs, serverCommonPath, DataType.ASCII);
+      return {status: true, details: {yaml, yamlSchema, serverCommon}};
+    } catch {
+      return {status: false, details: {yaml: '', yamlSchema: '', serverCommon: ''}}  
+    } 
   }
 
   async checkInstallData() {

--- a/src/renderer/components/stages/connection/Connection.tsx
+++ b/src/renderer/components/stages/connection/Connection.tsx
@@ -43,7 +43,8 @@ const Connection = () => {
   const stageLabel = 'Connection';
 
   const dispatch = useAppDispatch();
-  const zoweCLIVersion = useAppSelector(selectZoweCLIVersion);
+  // const zoweCLIVersion = useAppSelector(selectZoweCLIVersion);
+  const zoweCLIVersion = ''; // Removing for now as not implemented
   const [expanded, setExpanded] = React.useState<string | false>('FTPConn');
 
   const handleChange = (panel: string) => (event: React.SyntheticEvent, isExpanded: boolean) => {


### PR DESCRIPTION
Replacing cat command output parsing with file downloading for example-zowe.yaml and schemas

Also removing Zowe CLI connection check again as it was overwritten by some other PR. 