### PR TITLE
Added word wrap to the Editor (helps with viewing 1 line errors)

### DIFF
--- a/src/renderer/components/common/MonacoEditor.tsx
+++ b/src/renderer/components/common/MonacoEditor.tsx
@@ -50,7 +50,8 @@ const MonacoEditorComponent = ({contentType, initialContent, onContentChange, is
       language: lang, 
       theme: theme,
       value: initialContent,
-      readOnly: readOnly
+      readOnly: readOnly,
+      wordWrap: 'on'  // TODO: Make a button for it
     });
 
     editorRef.current.onDidChangeModelContent(() => {

--- a/src/services/ServiceUtils.ts
+++ b/src/services/ServiceUtils.ts
@@ -89,7 +89,7 @@ export function reducePath(path: string): string {
   return path; // stops at "/"
 }
 
-// This adds a "\n" inside Unix commands separated by ";" if char limit reached
+// This adds a "\n" inside Unix commands if char limit reached
 export function parseUnixScriptByNumOfChars(script: string, charCount: number = JCL_UNIX_SCRIPT_CHARS): string {
   const parts: string[] = [];
   let currentPart = '';


### PR DESCRIPTION
This makes the errors received in places like zwe install (the `[0: { nskdansndanjsd [....] }]` ones) a lot more readable when the error is really long 1 line

We still have work to do to show errors better in UI but this helps.