### PR TITLE
Bugfix - Security Tab

### DIFF
--- a/src/renderer/components/common/JsonForms.tsx
+++ b/src/renderer/components/common/JsonForms.tsx
@@ -107,28 +107,15 @@ const conditionalSchema = (schema: any, formData: any, prop: any): boolean=> {
 
 export default function JsonForm(props: any) {
   const {schema, onChange, formData} = props;
-  const [localFormData, setLocalFormData] = useState(formData || {});
 
-  // const isFormDataEmpty = formData === null || formData === undefined || Object.keys(formData).length < 1;
-  const isFormDataEmpty = localFormData === null || localFormData === undefined || Object.keys(localFormData).length < 1;
-
-  useEffect(() => {
-    setLocalFormData(formData);
-    console.log("Form Data Updated");
-  }, [formData])
+  const isFormDataEmpty = formData === null || formData === undefined || Object.keys(formData).length < 1;
 
   useEffect(() => {
     if (isFormDataEmpty) {
       const defaultFormData = getDefaultFormData(schema, formData);
-      setLocalFormData(defaultFormData);
       onChange(defaultFormData);
     }
   }, [isFormDataEmpty, schema, onChange]);
-
-  const onJsonFormChange = (data: any) => {
-    setLocalFormData(data);
-    onChange(data);
-  }
 
   const getDefaultFormData = (schema: any, formData: any) => {
     if (schema && schema.properties) {
@@ -162,7 +149,7 @@ export default function JsonForm(props: any) {
       renderers={materialRenderers}
       cells={materialCells}
       config={{showUnfocusedDescription: true}}
-      onChange={({ data, errors }) => { onJsonFormChange(data) }}
+      onChange={({ data, errors }) => { onChange(data) }}
     />
     </ThemeProvider>
   );

--- a/src/renderer/components/common/JsonForms.tsx
+++ b/src/renderer/components/common/JsonForms.tsx
@@ -107,15 +107,28 @@ const conditionalSchema = (schema: any, formData: any, prop: any): boolean=> {
 
 export default function JsonForm(props: any) {
   const {schema, onChange, formData} = props;
+  const [localFormData, setLocalFormData] = useState(formData || {});
 
-  const isFormDataEmpty = formData === null || formData === undefined;
+  // const isFormDataEmpty = formData === null || formData === undefined || Object.keys(formData).length < 1;
+  const isFormDataEmpty = localFormData === null || localFormData === undefined || Object.keys(localFormData).length < 1;
+
+  useEffect(() => {
+    setLocalFormData(formData);
+    console.log("Form Data Updated");
+  }, [formData])
 
   useEffect(() => {
     if (isFormDataEmpty) {
       const defaultFormData = getDefaultFormData(schema, formData);
+      setLocalFormData(defaultFormData);
       onChange(defaultFormData);
     }
   }, [isFormDataEmpty, schema, onChange]);
+
+  const onJsonFormChange = (data: any) => {
+    setLocalFormData(data);
+    onChange(data);
+  }
 
   const getDefaultFormData = (schema: any, formData: any) => {
     if (schema && schema.properties) {
@@ -149,7 +162,7 @@ export default function JsonForm(props: any) {
       renderers={materialRenderers}
       cells={materialCells}
       config={{showUnfocusedDescription: true}}
-      onChange={({ data, errors }) => { onChange(data) }}
+      onChange={({ data, errors }) => { onJsonFormChange(data) }}
     />
     </ThemeProvider>
   );

--- a/src/renderer/components/common/JsonForms.tsx
+++ b/src/renderer/components/common/JsonForms.tsx
@@ -105,47 +105,40 @@ const conditionalSchema = (schema: any, formData: any, prop: any): boolean=> {
   return false;
 }
 
+const getDefaultFormData = (schema: any, formData: any) => {
+  if (schema && schema.properties) {
+    const defaultFormData = { ...formData };
+    Object.keys(schema.properties).forEach((property) => {
+      if (schema.properties[property].type && schema.properties[property].default !== undefined || schema.properties[property].type === 'object') {
+        // If the property is an object, recursively set default values
+        if (schema.properties[property].type === 'object') {
+          defaultFormData[property] = getDefaultFormData(
+            schema.properties[property],
+            defaultFormData[property] || {}
+          );
+        } else {
+          defaultFormData[property] = schema.properties[property].default;
+        }
+      }
+    });
+    return defaultFormData;
+  }
+  return null;
+};
+
 export default function JsonForm(props: any) {
   const {schema, onChange, formData} = props;
 
   const isFormDataEmpty = formData === null || formData === undefined || Object.keys(formData).length < 1;
 
-  useEffect(() => {
-    if (isFormDataEmpty) {
-      const defaultFormData = getDefaultFormData(schema, formData);
-      onChange(defaultFormData);
-    }
-  }, [isFormDataEmpty, schema, onChange]);
-
-  const getDefaultFormData = (schema: any, formData: any) => {
-    if (schema && schema.properties) {
-      const defaultFormData = { ...formData };
-      Object.keys(schema.properties).forEach((property) => {
-        if (schema.properties[property].type && schema.properties[property].default !== undefined || schema.properties[property].type === 'object') {
-          // If the property is an object, recursively set default values
-          if (schema.properties[property].type === 'object') {
-            defaultFormData[property] = getDefaultFormData(
-              schema.properties[property],
-              defaultFormData[property] || {}
-            );
-          } else {
-            defaultFormData[property] = schema.properties[property].default;
-          }
-        }
-      });
-      return defaultFormData;
-    }
-    return null;
-  };
-
-  // const [formState, setFormState] = useState(isFormDataEmpty ? getDefaultFormData(schema, {}) : formData);
+  const formDataToUse = isFormDataEmpty ? getDefaultFormData(schema, {}) : formData;
 
   return (
     <ThemeProvider theme={jsonFormTheme}>
     <JsonForms
       schema={schema}
       uischema={makeUISchema(schema, '/', formData)}
-      data={formData}
+      data={formDataToUse}
       renderers={materialRenderers}
       cells={materialCells}
       config={{showUnfocusedDescription: true}}

--- a/src/renderer/components/stages/Security.tsx
+++ b/src/renderer/components/stages/Security.tsx
@@ -43,7 +43,7 @@ const Security = () => {
   const [schema, setLocalSchema] = useState(useAppSelector(selectSchema));
   const [yaml, setLocalYaml] = useState(useAppSelector(selectYaml));
   const [setupSchema] = useState(schema?.properties?.zowe?.properties?.setup?.properties?.security);
-  const [setupYaml, setSetupYaml] = useState(yaml?.zowe?.setup?.security ?? {product: 'RACF'});
+  const [setupYaml, setSetupYaml] = useState(yaml?.zowe?.setup?.security);
   const [showProgress, setShowProgress] = useState(getProgress('securityStatus'));
   const [init, setInit] = useState(false);
   const [editorVisible, setEditorVisible] = useState(false);

--- a/src/renderer/components/stages/Security.tsx
+++ b/src/renderer/components/stages/Security.tsx
@@ -213,7 +213,7 @@ const Security = () => {
   }
 
   const handleFormChange = (data: any) => {
-    let newData = init ? (Object.keys(setupYaml).length > 0 ? setupYaml : data?.zowe?.setup?.security) : (data?.zowe?.setup?.security ? data?.zowe?.setup?.security : data);
+    let newData = (init && setupYaml) ? (Object.keys(setupYaml).length > 0 ? setupYaml : data?.zowe?.setup?.security) : (data?.zowe?.setup?.security ? data?.zowe?.setup?.security : data);
     setInit(false);
 
     if (newData) {

--- a/src/renderer/components/stages/installation/Installation.tsx
+++ b/src/renderer/components/stages/installation/Installation.tsx
@@ -159,6 +159,7 @@ const Installation = () => {
     setIsFormInit(true);
 
     dispatch(setNextStepEnabled(getProgress('datasetInstallationStatus')));
+    dispatch(setNextStepEnabled(true));
     
     if(installationType === 'smpe') {
       const status = getProgress('datasetInstallationStatus');

--- a/src/renderer/components/stages/installation/Installation.tsx
+++ b/src/renderer/components/stages/installation/Installation.tsx
@@ -159,7 +159,6 @@ const Installation = () => {
     setIsFormInit(true);
 
     dispatch(setNextStepEnabled(getProgress('datasetInstallationStatus')));
-    dispatch(setNextStepEnabled(true));
     
     if(installationType === 'smpe') {
       const status = getProgress('datasetInstallationStatus');


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

This PR addresses Issue: 
When the security tab is launched for the first time, this PR populates the fields with the default values

This PR depends upon the following PRs:

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Change in a documentation
- [ ] Refactor the code 
- [ ] Chore, repository cleanup, updates the dependencies.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## PR Checklist
Please delete options that are not relevant.
- [ ] If the changes in this PR are meant for the next release / mainline, this PR targets a "staging" branch.
- [ ] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zen/blob/v2.x/staging/CONTRIBUTING.md))
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
<!-- - [ ] Relevant update to CHANGELOG.md -->
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, or if there are follow-up tasks and TODOs etc... -->
