### PR TITLE
Chore/planning stage

### DIFF
--- a/src/renderer/components/stages/Planning.tsx
+++ b/src/renderer/components/stages/Planning.tsx
@@ -91,7 +91,7 @@ const Planning = () => {
 
   const setLocValidations = (status: boolean): void => {
     setLocationsValidated(status);        // This sets component state and uses it for rendering.
-    dispatch(setIsLocationValid(status)); // This is an odd usage of redux. It sets variable to the redux state but never uses it, doesn't even have a selector, instead, it obscurely sets it to the localStorage via setPlanningStageStatus for persistance;
+    dispatch(setIsLocationValid(status)); // This is an odd usage of redux. It sets variable to the redux state but never uses it, doesn't even have a selector, instead, it obscurely sets it to the localStorage via setPlanningStageStatus for persistence;
   }
 
   const setValDetails = (details: any): void => { // Created a similar function for duplicated setting
@@ -157,7 +157,7 @@ const Planning = () => {
   const validateLocations = (e: any) => {
     // REVIEW: Four storages are used for these values, i've removed a pile of setters from here, but it still should be done better.
     // On every form change we run formChangeHandler and setYaml to store config in the redux (1) for the UI - ok
-    // Also we set electron-storage (2) (window.electron.ipcRenderer.setConfigByKeyNoValidate) for persistance, which may be a bit heavy, persistance data can be saved after successful validation here in validateLocations. 
+    // Also we set electron-storage (2) (window.electron.ipcRenderer.setConfigByKeyNoValidate) for persistence, which may be a bit heavy, persistence data can be saved after successful validation here in validateLocations. 
     // And as the same time here we have some metadata storage like setValDetails, which use the component state (3) setValidationDetails and the localStorage (4) setPlanningValidationDetailsState(details) 
 
     e.preventDefault();
@@ -480,9 +480,11 @@ Please customize the job statement below to match your system requirements.
             control={
               <Checkbox // TODO: Add z/OSMF off support
                 checked={true}
+                disabled={true}
+                title="Disabling the z/OSMF support is not implemented"
                 onChange={(e) => {
-                  setShowZosmfAttributes(true);
-                  formChangeHandler();
+                  // setShowZosmfAttributes(true);
+                  // formChangeHandler();
                 }}
               />
             }

--- a/src/renderer/components/stages/Planning.tsx
+++ b/src/renderer/components/stages/Planning.tsx
@@ -224,7 +224,7 @@ const Planning = () => {
           const dfOut: string = res[3].details.split('\n').filter((i: string) => i.trim().startsWith(localYaml?.zowe?.runtimeDirectory.slice(0, 3)))[0];
           details.spaceAvailableMb = dfOut.match(/\d+\/\d+/g)[0].split('/')[0];
           if (parseInt(details.spaceAvailableMb, 10) < requiredSpace) { 
-            alertEmitter.emit('showAlert', `Can't validate available space, please make sure you have enough free space in ${localYaml?.zowe?.runtimeDirectory}`, 'info');
+            alertEmitter.emit('showAlert', `Can't validate available space, please make sure you have enough free space in ${localYaml?.zowe?.runtimeDirectory}`, 'info', 10000);
             // details.error = details.error + `Not enough space, you need at least ${requiredSpace}MB; `;
           }
         } catch (error) {
@@ -242,6 +242,13 @@ const Planning = () => {
           }));
         } else {
           alertEmitter.emit('showAlert', details.error, 'error');
+        }
+      }).finally(() => {
+        // TODO: Make it more smart, add these checks to the planning validation details and verify the input fields one by one with a status icon.
+        if (localYaml?.zowe?.logDirectory.startsWith(localYaml?.zowe?.runtimeDirectoryy) ||
+            localYaml?.zowe?.workspaceDirectory.startsWith(localYaml?.zowe?.runtimeDirectory) ||
+            localYaml?.zowe?.extensionDirectory.startsWith(localYaml?.zowe?.runtimeDirectory)) {
+            alertEmitter.emit('showAlert', `Some instance locations (workspace, logs or extensions) are defined inside the runtime directory ${localYaml?.zowe?.runtimeDirectory}. It is not recommended as the runtime directory ment to be read-only.`, 'warning', 20000);
         }
       })
     }
@@ -476,7 +483,7 @@ Please customize the job statement below to match your system requirements.
           </FormControl>
           </div>
           </div>
-          <FormControlLabel
+          {/* <FormControlLabel
             control={
               <Checkbox // TODO: Add z/OSMF off support
                 checked={true}
@@ -489,8 +496,7 @@ Please customize the job statement below to match your system requirements.
               />
             }
             label="Set z/OSMF Attributes (Recommended)"
-          />
-
+          /> */}
           {showZosmfAttributes && (
             <div style={{ display: 'flex', justifyContent: 'space-between' }}>
               <div style={{ flex: 1 }}>

--- a/src/renderer/components/stages/Planning.tsx
+++ b/src/renderer/components/stages/Planning.tsx
@@ -17,171 +17,96 @@ import FormControl from '@mui/material/FormControl';
 import Button from '@mui/material/Button';
 import ContainerCard from '../common/ContainerCard';
 import CheckCircle from '@mui/icons-material/CheckCircle';
+import { Checkbox, FormControlLabel } from "@mui/material";
 import { setYaml, setNextStepEnabled, setLoading, selectYaml } from '../configuration-wizard/wizardSlice';
-import { selectConnectionArgs, setConnectionArgs, setJobStatementVal } from './connection/connectionSlice';
-import { setPlanningStatus, selectPlanningStatus } from './progress/progressSlice';
-import { setZoweVersion, setInstallationArgs, selectInstallationArgs, selectZoweVersion } from './installation/installationSlice';
-import { setJobStatement, setJobStatementValid, setJobStatementValidMsg, setLocationValidationDetails, setIsLocationValid, selectJobStatementValidMsg, selectLocValidationDetails } from "./PlanningSlice";
+import { selectConnectionArgs, selectInitJobStatement, setJobStatementVal } from './connection/connectionSlice'; // looks like job statement does not belong to the connection store, or it is, it used for running commands on mf
+import { setPlanningStatus } from './progress/progressSlice';
+import { setInstallationArgs, selectInstallationArgs } from './installation/installationSlice'; // locations go there
+import { setJobStatementValid, setIsLocationValid } from "./PlanningSlice"; // and here, locations and job statement, checks should go th the progress store
 import { useAppDispatch, useAppSelector } from '../../hooks';
 import { IResponse } from '../../../types/interfaces';
 import { alertEmitter } from "../Header";
-import { Checkbox, FormControlLabel } from "@mui/material";
-import { setActiveStep } from './progress/activeStepSlice';
-import EditorDialog from "../common/EditorDialog";
+import { setActiveStep } from './progress/activeStepSlice'; // This part can be handled in wizardSlice
 import { getStageDetails } from "../../../services/StageDetails";
-import { getProgress, getPlanningStageStatus, setPlanningValidationDetailsState, getPlanningValidationDetailsState, getInstallationTypeStatus } from "./progress/StageProgressStatus";
+import { getProgress, getPlanningStageStatus, setPlanningValidationDetailsState, getPlanningValidationDetailsState, getInstallationTypeStatus } from "./progress/StageProgressStatus"; // localStorage
 import { FALLBACK_YAML, isValidUSSPath } from "../common/Utils";
 
 // TODO: Our current theoretical cap is 72 (possibly minus a couple for "\n", 70?) But we force more chars in InstallationHandler.tsx
 // This is all I want to manually test for now. Future work can min/max this harder
 const JCL_UNIX_SCRIPT_CHARS = 55;
 
-
 // TODO: Planning stage has no schema validation. Current schema validation method relies on just existence of property (removed)
 
 const Planning = () => {
 
-  const [stageLabel] = useState('Planning');
-
+  const stageLabel = 'Planning';
   const STAGE_ID = getStageDetails(stageLabel).id;
   const SUB_STAGES = !!getStageDetails(stageLabel).subStages;
 
   const dispatch = useAppDispatch();
 
   const connectionArgs = useAppSelector(selectConnectionArgs);
-  const [localYaml, setLocalYaml] = useState(useAppSelector(selectYaml));
-
-  // const jobStatementValid = useAppSelector(selectJobStatementValid);
-  const [jobStatementValid, setJobStatementValidation] = useState(getPlanningStageStatus()?.isJobStatementValid);
-  const jobStatementValidMsg = useAppSelector(selectJobStatementValidMsg);
-
-  const locationValidationDetails = useAppSelector(selectLocValidationDetails);
-
-  const planningStatus = useAppSelector(selectPlanningStatus);
-  
+  const localYaml = useAppSelector(selectYaml);
   const [step, setStep] = useState(0);
 
-  const [jobHeaderSaved, setJobHeaderSaved] = useState(false);
-  const [isJobStatementUpdated, setIsJobStatementUpdated] = useState(false);
-  // const [jobStatementValue, setJobStatementValue] = useState(useAppSelector(selectJobStatement));
-  const [jobStatementValue, setJobStatementValue] = useState(getPlanningStageStatus()?.jobStatement);
-  
-  const [locationsValidated, setLocationsValidated] = useState(getPlanningStageStatus()?.isLocationValid || false);
-  const [isLocationsUpdated, setIsLocationsUpdated] = useState(false);
+  // REVIEW: Instead of redux + electron-store we use here state + local storage + ?
+  const [jobHeaderSaved, setJobHeaderSaved] = useState(getPlanningStageStatus()?.isJobStatementValid);
+  const jobStatementValue = useAppSelector(selectInitJobStatement);
+
+  const [locationsValidated, setLocationsValidated] = useState(getPlanningStageStatus()?.isLocationValid);
   const [validationDetails, setValidationDetails] = useState(getPlanningValidationDetailsState());
+  
   const [showZosmfAttributes, setShowZosmfAttributes] = useState(true);
 
-  const zoweVersion = useAppSelector(selectZoweVersion);
-  const [installationArgs, setInstArgs] = useState(useAppSelector(selectInstallationArgs));
-  const [requiredSpace, setRequiredSpace] = useState(1300); //in megabytes
-
-  const [contentType, setContentType] = useState('output');
-  const [editorVisible, setEditorVisible] = useState(false);
-  const [editorContent, setEditorContent] = useState('');
-
-  const toggleEditorVisibility = (type?: any) => {
-    if (type) {
-      setContentType(type);
-    }
-    setEditorVisible(!editorVisible);
-  };
+  const installationArgs = useAppSelector(selectInstallationArgs);
+  const requiredSpace = 1300; //in megabytes
 
   useEffect(() => {
-    const nextPosition = document.getElementById('container-box-id');
-    nextPosition.scrollIntoView({behavior: 'smooth', block: 'start'});
-
-    if(getPlanningStageStatus()?.isJobStatementValid) {
-      setJobHeaderSaved(true);
-      if(getPlanningStageStatus()?.isLocationValid) {
-        setStep(2);
-      } else {
-        setStep(1);
-      }
-    }
-    return () => {
-      dispatch(setActiveStep({ activeStepIndex: STAGE_ID, isSubStep: SUB_STAGES, activeSubStepIndex: 0 }));
-    }
-  }, [])
-
-  useEffect(() => {
-    setPlanningState(getProgress('planningStatus'));
+    // const nextPosition = document.getElementById('container-box-id');   // REVIEW: Can't recall why we have this
+    // nextPosition.scrollIntoView({behavior: 'smooth', block: 'start'});
+    // setPlanningState(getProgress('planningStatus'));
     // FIXME: Add a popup warning in case failed to get config files
     // FIXME: Save yaml and schema on disk to not to pull it each time?
     // REVIEW: Replace JobStatement text area with set of text fields?
 
-    dispatch(setJobStatementVal(jobStatementValue));
+    if (jobHeaderSaved) {
+      locationsValidated ? setStep(2) : setStep(1);
+    }
 
-    if(!installationArgs.dryRunMode){
-      window.electron.ipcRenderer.getZoweVersion().then((res: IResponse) => dispatch(setZoweVersion(res.status ? res.details : '' )));
-      
+    // dispatch(setJobStatementVal(jobStatementValue)); // REVIEW: Storage duplication
+
+    if (!installationArgs.dryRunMode) { // REVIEW: Does dry run even makes sense in this step? What do we want to get as a result? If it is a dry run mode we do nothing? 
       window.electron.ipcRenderer.getConfigByKey("installationArgs").then((res: IResponse) => {
-      if(res != undefined){
-        setInstArgs((res as any));
-      }
+        if (res != undefined) {
+          dispatch(setInstallationArgs(res));
+        }
       })
 
-    window.electron.ipcRenderer.getConfig().then((res: IResponse) => {
-      if (res.status) {
-        dispatch(setYaml(res.details));
-        setLocalYaml(res.details);
-        let installationDir = '';
-        if (res.details?.zowe?.runtimeDirectory && res.details?.zowe?.workspaceDirectory) {
-          const getParentDir = (path: string): string => path.split('/').filter((i: string, ind: number) => i || !ind).slice(0, -1).join('/');
-          const runtimeParent = getParentDir(res.details?.zowe?.runtimeDirectory);
-          const workspaceParent = getParentDir(res.details?.zowe?.workspaceDirectory);
-          if (runtimeParent === workspaceParent) installationDir = runtimeParent;
+      window.electron.ipcRenderer.getConfig().then((res: IResponse) => {
+        if (res.status) {
+          dispatch(setYaml(res.details));
+          dispatch(setInstallationArgs({...installationArgs, installationType: getInstallationTypeStatus()?.installationType, userUploadedPaxPath: getInstallationTypeStatus()?.userUploadedPaxPath}));
         }
-        dispatch(setInstallationArgs({...installationArgs, installationDir: res.details?.zowe?.runtimeDirectory ?? '', installationType: getInstallationTypeStatus()?.installationType, userUploadedPaxPath: getInstallationTypeStatus()?.userUploadedPaxPath}));
-      }
-    })
-  }
+      })
+    }
+    return () => {
+      dispatch(setActiveStep({ activeStepIndex: STAGE_ID, isSubStep: SUB_STAGES, activeSubStepIndex: 0 }));
+    }
   }, []); 
   
   useEffect(() => {
-    setPlanningState(jobHeaderSaved && locationsValidated);
+    dispatch(setNextStepEnabled(jobHeaderSaved && locationsValidated));
+    dispatch(setPlanningStatus(jobHeaderSaved && locationsValidated));
   }, [jobHeaderSaved, locationsValidated]);
 
   useEffect(() => {
     const nextPosition = document.getElementById(`position-${step}`);
     nextPosition.scrollIntoView({behavior: 'smooth'});
-
-    /* TODO: Fixes "Please fill in all remaining values" bug
-    This sets the localYaml values to installationArg values in case they have been pre-populated by the UI
-    (when onChange detectors haven't run yet to do the job of setting localYaml). This is a workaround and should
-    be investigated why edgecases exist where the UI input fields has text visible, yet localYaml is not set */
-    if (!localYaml?.java?.home && installationArgs.javaHome)
-    {
-      const updatedYaml: any = updateAndReturnYaml('java.home', installationArgs.javaHome)
-      dispatch(setYaml(updatedYaml));
-      setLocalYaml(updatedYaml);
-    }
-    if (!localYaml?.node?.home && installationArgs.nodeHome)
-    {
-      const updatedYaml: any = updateAndReturnYaml('node.home', installationArgs.nodeHome)
-      dispatch(setYaml(updatedYaml));
-      setLocalYaml(updatedYaml);
-    }
-    if (!localYaml?.zowe?.runtimeDirectory && installationArgs.installationDir)
-    {
-      const updatedYaml: any = updateAndReturnYaml('zowe.runtimeDirectory', installationArgs.installationDir)
-      dispatch(setYaml(updatedYaml));
-      setLocalYaml(updatedYaml);
-    }
   }, [step]);
 
-  const setPlanningState = (status: boolean): void => {
-    dispatch(setNextStepEnabled(status));
-    dispatch(setPlanningStatus(status));
-  }
-
   const setLocValidations = (status: boolean): void => {
-    setLocationsValidated(status);
+    setLocationsValidated(status); // REVIEW: Storage duplication
     dispatch(setIsLocationValid(status));
-  }
-
-  const setEditorContentAndType = (content: any, type: string): void => {
-    setEditorContent(content);
-    setContentType(type);
   }
 
   const getENVVars = () => {
@@ -189,14 +114,10 @@ const Planning = () => {
       if (res.status) {
         try {
           const lines = res.details.split('\n').map((l: string) => l.trim()).filter((l: string) => !l.includes("echo"));
-          let nodeHome, javaHome;
           lines.map((line: string) => {
-            if (line.includes('node')) nodeHome = installationArgs.nodeHome ? installationArgs.nodeHome : line;
-            if (line.includes('java')) javaHome = installationArgs.javaHome ? installationArgs.javaHome : line;
+            if (line.includes('node') && !localYaml?.node?.home) dispatch(setYaml(updateAndReturnYaml('node.home', line)));
+            if (line.includes('java') && !localYaml?.java?.home) dispatch(setYaml(updateAndReturnYaml('java.home', line)));
           });
-          nodeHome && dispatch(setInstallationArgs({...installationArgs, nodeHome: nodeHome}))
-          javaHome && dispatch(setInstallationArgs({...installationArgs, javaHome: javaHome}))
-
         } catch (error) {
           return {status: false, details: error.message}
         }
@@ -206,36 +127,24 @@ const Planning = () => {
   }
 
   const saveJobHeader = (e: any) => {
-
-    if(jobStatementValid && !isJobStatementUpdated) {
-      setJobHeaderSaved(true);
-      setEditorContentAndType(jobStatementValidMsg, 'output');
-      if (step < 1) {
-        setStep(1);
-      }
-      if(planningStatus && !isLocationsUpdated) {
-        validateLocations(null);
-      }
-      return;
-    }
     e.preventDefault();
+    alertEmitter.emit('hideAlert');
     dispatch(setLoading(true));
 
-    if(!installationArgs.dryRunMode){
-      window.electron.ipcRenderer.saveJobHeader(jobStatementValue)
+    if (!installationArgs.dryRunMode) {
+      window.electron.ipcRenderer.saveJobHeader(jobStatementValue)  // Saves to the connection store, ok
       .then(() => getENVVars())
       .then((res: IResponse) => {
-        setEditorContentAndType(res.details, 'output');
         if (!res.status) { // Failure case
-          dispatch(setJobStatementValidMsg(res.details));
+          dispatch(setJobStatementValid(false));
           console.warn('Failed to verify job statement', res.details);
           // TODO: This more detailed reason, for why Job submission failed, may be large and should be opened in an Editor
+          // dispatch(setJobStatementValidMsg(res.details)); 
           alertEmitter.emit('showAlert', 'Failed to verify job statement ' + res.details, 'error');
         } else { // Success JCL case
           dispatch(setJobStatementValid(true));
-          alertEmitter.emit('hideAlert');
           if(locationsValidated) {
-            setPlanningState(true);
+            // setPlanningState(true);
             setStep(2);
           } else if (step < 1) {
             setStep(1);
@@ -245,19 +154,16 @@ const Planning = () => {
         dispatch(setLoading(false));
       })
       .catch((err: Error) => {
-        setEditorContentAndType(err.message, 'output');
         console.warn(err);
-        dispatch(setJobStatementValidMsg(err.message));
         dispatch(setJobStatementValid(false));
         alertEmitter.emit('showAlert', err.message, 'error');
         dispatch(setLoading(false));
       });    
-    } else{
-      if(locationsValidated){
-        setPlanningState(true);
+    } else {
+      if (locationsValidated) {
+        // setPlanningState(true);
         setStep(2);
-      } else if (step<1)
-      {
+      } else if (step < 1) {
         setStep(1);
       }
       setJobHeaderSaved(true);
@@ -266,41 +172,30 @@ const Planning = () => {
     }
   }
     
-  const validateLocations = (e: any, click?: boolean) => {
-    setPlanningState(false);
-    setLocValidations(false);
-   
-    if(planningStatus && !isLocationsUpdated && !click) {
-      setLocValidations(true);
-      setPlanningState(true);
-      setValidationDetails(locationValidationDetails);
-      setPlanningValidationDetailsState(locationValidationDetails);
-      setEditorContentAndType(jobStatementValidMsg, 'output');
-      setStep(2);
-      return;
-    }
-
+  const validateLocations = (e: any) => {
     e.preventDefault();
+    alertEmitter.emit('hideAlert');
+    // setPlanningState(false);
+    setLocValidations(false);
     setValidationDetails({...validationDetails, error: ''});
+
     if (!localYaml?.java?.home || !localYaml?.node?.home || !localYaml?.zowe?.runtimeDirectory) {
       console.warn('Please fill in all values');
       alertEmitter.emit('showAlert', 'Please fill in all values', 'error');
-      //showAlert('Please fill in all values', 'success', 5000);
       return;
     }
     dispatch(setLoading(true));
 
     // TODO: Possible feature for future: add to checkDir to see if existing Zowe install exists.
     // Then give the user ability to use existing zowe.yaml to auto-fill in fields from Wizard
-    if(!installationArgs.dryRunMode){
+    if (!installationArgs.dryRunMode) {
+
       Promise.all([
-        window.electron.ipcRenderer.checkJava(connectionArgs, localYaml?.java?.home || installationArgs.javaHome),
-        window.electron.ipcRenderer.checkNode(connectionArgs, localYaml?.node?.home || installationArgs.nodeHome),
-        window.electron.ipcRenderer.checkDirOrCreate(connectionArgs, localYaml?.zowe?.runtimeDirectory || installationArgs.installationDir),
+        window.electron.ipcRenderer.checkJava(connectionArgs, localYaml?.java?.home),
+        window.electron.ipcRenderer.checkNode(connectionArgs, localYaml?.node?.home),
+        window.electron.ipcRenderer.checkDirOrCreate(connectionArgs, localYaml?.zowe?.runtimeDirectory),
       ]).then((res: Array<IResponse>) => {
       const details = {javaVersion: '', nodeVersion: '', spaceAvailableMb: '', error: ''};
-      setEditorContent(res.map(item=>item?.details).join('\n'));
-      setContentType('output');
 
       if (localYaml?.zowe?.logDirectory && !isValidUSSPath(localYaml.zowe.logDirectory)) {
         details.error = localYaml.zowe.logDirectory + " is not a valid z/OS Unix path"
@@ -328,7 +223,7 @@ const Planning = () => {
         details.error = details.error + res[2].details;
         console.warn(res[2].details);
       }
-      //Do not check space because space on ZFS is dynamic. you can have more space than USS thinks.
+      //Do not check space because space on ZFS is dynamic. you can have more space than USS thinks. // REVIEW: Still can check and show notification instead of error
       // try {
         //   const dfOut: string = res[2].details.split('\n').filter((i: string) => i.trim().startsWith(installationArgs.installationDir.slice(0, 3)))[0];
         //   details.spaceAvailableMb = dfOut.match(/\d+\/\d+/g)[0].split('/')[0];
@@ -340,63 +235,57 @@ const Planning = () => {
           //   details.error = details.error + `Can't check space available; `;
           //   console.warn(res[2].details);
           // }
-          setValidationDetails(details);
-          setPlanningValidationDetailsState(details);
-          dispatch(setLocationValidationDetails(details))
-          dispatch(setLoading(false));
-          if (!details.error) {
-            alertEmitter.emit('hideAlert');
-            setLocValidations(true);
-            setPlanningState(true);
-            // setStep(2); // This step is meant to show some usefull status, removing for now.
-          } else {
-        dispatch(setPlanningStatus(false));
+      setValidationDetails(details); // REVIEW: Three times?
+      setPlanningValidationDetailsState(details);
+      // dispatch(setLocationValidationDetails(details)); 
+      dispatch(setLoading(false));
+      if (!details.error) {
+        setLocValidations(true);
+        setStep(2);
+      } else {
         dispatch(setLoading(false));
         alertEmitter.emit('showAlert', details.error, 'error');
       }
-    })
+      })
+    }
+    else {
+      setLocValidations(true);
+      dispatch(setLoading(false));
+    }
   }
-  else{
-    setPlanningState(true);
-    setLocValidations(true);
-    dispatch(setLoading(false));
+        
+  const onJobStatementChange = (newJobStatement: string) => {
+    setJobHeaderSaved(false);
+    dispatch(setJobStatementVal(newJobStatement));
+    // setJobStatementValidation(false);
+    dispatch(setJobStatementValid(false));
+    // setPlanningState(false);
+    setStep(0);
   }
-}
         
-const onJobStatementChange = (newJobStatement: string) => {
-          setIsJobStatementUpdated(true);
-          setJobStatementValue(newJobStatement);
-          setJobHeaderSaved(false);
-          setJobStatementValidation(false);
-          dispatch(setJobStatement(newJobStatement));
-          dispatch(setJobStatementValid(false));
-          setPlanningState(false);
-          setStep(0);
-        }
-        
-        const formChangeHandler = (key?: string, value?: (string | number), installationArg?: string) => {
-          setIsLocationsUpdated(true);
-          setPlanningStatus(false);
-          setLocationsValidated(false);
-          dispatch(setPlanningStatus(false));
-          dispatch(setNextStepEnabled(false));
-          setStep(1);
+  const formChangeHandler = (key?: string, value?: (string | number), installationArg?: string) => {
+    setLocationsValidated(false);
+    // setIsLocationsUpdated(true);
+    // setPlanningStatus(false);  // There even a typo in function name because it is a duplicate,  setPlanningStatus should be dispatched, while setPlanningState is a local function
+    // dispatch(setPlanningStatus(false));
+    // dispatch(setNextStepEnabled(false)); // This is controlled by setPlanningState together with setPlanningStatus and it is duplicated by separate fuction probably because three lines above we have a typo
+                                         // So all of this should be controlled by setPlanningState, but it is controlled by two validations itself
+    setStep(1);
 
     if (!key || !value) {
       return;
     }
 
-    if(installationArg) {
-      const newInstallationArgs = { ...installationArgs, [installationArg]: value };
-      dispatch(setInstallationArgs(newInstallationArgs));
-      setInstArgs(newInstallationArgs);
-      window.electron.ipcRenderer.setConfigByKeyNoValidate("installationArgs", newInstallationArgs);
-    }
+    // REVIEW should not be handled anymore, just use vars from yaml
+    // if(installationArg) {
+    //   const newInstallationArgs = { ...installationArgs, [installationArg]: value };
+    //   dispatch(setInstallationArgs(newInstallationArgs));
+    //   window.electron.ipcRenderer.setConfigByKeyNoValidate("installationArgs", newInstallationArgs);
+    // }
 
     const updatedYaml: any = updateAndReturnYaml(key, value)
 
     dispatch(setYaml(updatedYaml));
-    setLocalYaml(updatedYaml);
   }
 
   const updateAndReturnYaml = (key: string, value: string | number) => {
@@ -419,12 +308,7 @@ const onJobStatementChange = (newJobStatement: string) => {
     <div id="container-box-id">
     <React.Fragment><span id="position-0"></span>
     <ContainerCard title="Before you start" description="Prerequisites, requirements and roles needed to install.">
-      <EditorDialog contentType={contentType} isEditorVisible={editorVisible} toggleEditorVisibility={toggleEditorVisibility} content={editorContent}/>
       <Box id="conatiner-box-id" sx={{height: step === 0 ? 'calc(100vh - 200px)' : 'auto'}}>
-        <Typography sx={{ mb: 2 }} color="text.secondary"> 
-          {/* TODO: Allow to choose Zowe version here by click here, support for other instalation types? */}
-          {zoweVersion ? `About to install latest Zowe version: ${zoweVersion} from the convenience build. Approximate required space: ${requiredSpace}MB` : ''}
-        </Typography>
         <Typography sx={{ mb: 2, whiteSpace: 'pre-wrap' }} color="text.secondary">     
         {/* <Describe permissions that may be needed in detail>  */}  
         {`The basic role for the installation is the system programmer ( OMVS / z/OS ) 
@@ -449,7 +333,7 @@ Please customize the job statement below to match your system requirements.
             multiline
             maxRows={6}
             value={jobStatementValue}
-            onChange={(e) => {dispatch(setConnectionArgs({...connectionArgs, jobStatement: e.target.value})); onJobStatementChange(e.target.value)}}
+            onChange={(e) => {dispatch(setJobStatementVal(e.target.value)); onJobStatementChange(e.target.value)}}
             variant="standard"
           />
         </FormControl>
@@ -465,7 +349,7 @@ Please customize the job statement below to match your system requirements.
           <Typography id="position-1" sx={{ mb: 2, whiteSpace: 'pre-wrap' }} color="text.secondary">       
             {`Now let's define some properties like z/OS Unix locations, identifiers, and (optionally) z/OSMF details.`}
           </Typography>
-          <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', paddingBottom: '32px' }}>
           <div style={{ flex: 1 }}>
           <FormControl>
             <div>
@@ -475,10 +359,10 @@ Please customize the job statement below to match your system requirements.
                 style={{marginLeft: 0}}
                 label="Run-time Directory (or installation location)"
                 variant="standard"
-                value={localYaml?.zowe?.runtimeDirectory || installationArgs.installationDir || ''}
+                value={localYaml?.zowe?.runtimeDirectory || ''}
                 inputProps={{ maxLength: JCL_UNIX_SCRIPT_CHARS }}
                 onChange={(e) => {
-                  formChangeHandler("zowe.runtimeDirectory", e.target.value, "installationDir");
+                  formChangeHandler("zowe.runtimeDirectory", e.target.value);
                   if(localYaml){
                     window.electron.ipcRenderer.setConfigByKeyNoValidate('zowe.runtimeDirectory', e.target.value).then((res: any) => {
                       // console.log('updated zowe.runtimeDirectory')
@@ -497,10 +381,10 @@ Please customize the job statement below to match your system requirements.
                 style={{marginLeft: 0}}
                 label="Workspace Directory"
                 variant="standard"
-                value={localYaml?.zowe?.workspaceDirectory || installationArgs.workspaceDir || FALLBACK_YAML.zowe.workspaceDirectory}
+                value={localYaml?.zowe?.workspaceDirectory || FALLBACK_YAML.zowe.workspaceDirectory}
                 inputProps={{ maxLength: JCL_UNIX_SCRIPT_CHARS }}
                 onChange={(e) => {
-                  formChangeHandler("zowe.workspaceDirectory", e.target.value, "workspaceDir");
+                  formChangeHandler("zowe.workspaceDirectory", e.target.value);
                   if(localYaml){
                     window.electron.ipcRenderer.setConfigByKeyNoValidate('zowe.workspaceDirectory', e.target.value).then((res: any) => {
                       // console.log('updated zowe.workspaceDirectory')
@@ -519,10 +403,10 @@ Please customize the job statement below to match your system requirements.
                 style={{marginLeft: 0}}
                 label="Log Directory"
                 variant="standard"
-                value={localYaml?.zowe?.logDirectory || installationArgs.logDir || FALLBACK_YAML.zowe.logDirectory}
+                value={localYaml?.zowe?.logDirectory || FALLBACK_YAML.zowe.logDirectory}
                 inputProps={{ maxLength: JCL_UNIX_SCRIPT_CHARS }}
                 onChange={(e) => {
-                  formChangeHandler("zowe.logDirectory", e.target.value, "logDir");
+                  formChangeHandler("zowe.logDirectory", e.target.value);
                   if(localYaml){
                     window.electron.ipcRenderer.setConfigByKeyNoValidate('zowe.logDirectory', e.target.value).then((res: any) => {
                       // console.log('updated zowe.logDirectory')
@@ -533,6 +417,8 @@ Please customize the job statement below to match your system requirements.
               <p style={{ marginTop: '5px', marginBottom: '0', fontSize: 'smaller', color: 'grey' }}>Read and writeable z/OS Unix location for Zowe's logs.</p>
             </div>
           </FormControl>
+          </div>
+          <div style={{ flex: 1 }}>
           <FormControl>
             <div>
               <TextField
@@ -541,10 +427,10 @@ Please customize the job statement below to match your system requirements.
                 style={{marginLeft: 0}}
                 label="Extensions Directory"
                 variant="standard"
-                value={localYaml?.zowe?.extensionDirectory || installationArgs.extensionDir || FALLBACK_YAML.zowe.extensionDirectory}
+                value={localYaml?.zowe?.extensionDirectory || FALLBACK_YAML.zowe.extensionDirectory}
                 inputProps={{ maxLength: JCL_UNIX_SCRIPT_CHARS }}
                 onChange={(e) => {
-                  formChangeHandler("zowe.extensionDirectory", e.target.value, "extensionDir");
+                  formChangeHandler("zowe.extensionDirectory", e.target.value);
                   if(localYaml){
                     window.electron.ipcRenderer.setConfigByKeyNoValidate('zowe.extensionDirectory', e.target.value).then((res: any) => {
                       // console.log('updated zowe.extensionDirectory')
@@ -558,100 +444,14 @@ Please customize the job statement below to match your system requirements.
           <FormControl>
             <div>
               <TextField
-                id="rbac-input"
-                required
-                style={{marginLeft: 0}}
-                label="Rbac Profile Identifier"
-                variant="standard"
-                value={localYaml?.zowe?.rbacProfileIdentifier || installationArgs.rbacProfile}
-                onChange={(e) => {
-                  formChangeHandler("zowe.rbacProfileIdentifier", e.target.value, "rbacProfile" );
-                  if(localYaml){
-                    window.electron.ipcRenderer.setConfigByKeyNoValidate('zowe.rbacProfileIdentifier', e.target.value).then((res: any) => {
-                      // console.log('updated zowe.rbacProfileIdentifier')
-                    })
-                  }
-                }}
-              />
-              <p style={{ marginTop: '5px', marginBottom: '0', fontSize: 'smaller', color: 'grey' }}>ID used for determining resource names as used in RBAC authorization checks.</p>
-            </div>
-          </FormControl>
-          </div>
-          <div style={{ flex: 1 }}>
-          <FormControl>
-            <div>
-              <TextField
-                id="job-name-input"
-                required
-                style={{marginLeft: 0}}
-                label="Job Name"
-                variant="standard"
-                value={localYaml?.zowe?.job?.name || installationArgs.jobName}
-                onChange={(e) => {
-                  formChangeHandler("zowe.job.name", e.target.value, "jobName");
-                  if(localYaml){
-                    window.electron.ipcRenderer.setConfigByKeyNoValidate('zowe.job.name', e.target.value).then((res: any) => {
-                      // console.log('updated zowe.job.name')
-                    })
-                  }
-                }}
-              />
-              <p style={{ marginTop: '5px', marginBottom: '0', fontSize: 'smaller', color: 'grey' }}>Job name of the Zowe primary ZWESLSTC started task.</p>
-            </div>
-          </FormControl>
-          <FormControl>
-            <div>
-              <TextField
-                id="job-prefix-input"
-                required
-                style={{marginLeft: 0}}
-                label="Job Prefix"
-                variant="standard"
-                value={localYaml?.zowe?.job?.prefix || installationArgs.jobPrefix}
-                onChange={(e) => {
-                  formChangeHandler("zowe.job.prefix", e.target.value, "jobPrefix");
-                  if(localYaml){
-                    window.electron.ipcRenderer.setConfigByKeyNoValidate('zowe.job.prefix', e.target.value).then((res: any) => {
-                      // console.log('updated zowe.job.prefi')
-                    })
-                  }
-                }}
-              />
-              <p style={{ marginTop: '5px', marginBottom: '0', fontSize: 'smaller', color: 'grey' }}>Short prefix to identify/customize address spaces created by the Zowe job.</p>
-            </div>
-          </FormControl>
-          <FormControl>
-            <div>
-              <TextField
-                id="cookie-input"
-                required
-                style={{marginLeft: 0}}
-                label="Cookie Identifier"
-                variant="standard"
-                value={localYaml?.zowe?.cookieIdentifier || installationArgs.cookieId}
-                onChange={(e) => {
-                  formChangeHandler("zowe.cookieIdentifier", e.target.value, "cookieId");
-                  if(localYaml){
-                    window.electron.ipcRenderer.setConfigByKeyNoValidate('zowe.cookieIdentifier', e.target.value).then((res: any) => {
-                      // console.log('updated zowe.cookieIdentifier')
-                    })
-                  }
-                }}
-              />
-              <p style={{ marginTop: '5px', marginBottom: '0', fontSize: 'smaller', color: 'grey' }}>ID that can be used by the servers to distinguish their cookies from unrelated Zowe installs.</p>
-            </div>
-          </FormControl>
-          <FormControl>
-            <div>
-              <TextField
                 id="java-home-input"
                 required
                 style={{marginLeft: 0}}
                 label="Java Home Directory"
                 variant="standard"
-                value={localYaml?.java?.home || installationArgs.javaHome || ''}
+                value={localYaml?.java?.home || ''}
                 onChange={(e) => {
-                  formChangeHandler("java.home", e.target.value, "javaHome");
+                  formChangeHandler("java.home", e.target.value);
                   if(localYaml){
                     window.electron.ipcRenderer.setConfigByKeyNoValidate('java.home', e.target.value).then((res: any) => {
                       // console.log('updated zowe.java.home')
@@ -670,9 +470,9 @@ Please customize the job statement below to match your system requirements.
                 style={{marginLeft: 0}}
                 label="Node.js Home Directory"
                 variant="standard"
-                value={localYaml?.node?.home || installationArgs.nodeHome || ''}
+                value={localYaml?.node?.home || ''}
                 onChange={(e) => {
-                  formChangeHandler("node.home", e.target.value, "nodeHome");
+                  formChangeHandler("node.home", e.target.value);
                   if(localYaml){
                     window.electron.ipcRenderer.setConfigByKeyNoValidate('node.home', e.target.value).then((res: any) => {
                       // console.log('updated zowe.node.home')
@@ -709,9 +509,9 @@ Please customize the job statement below to match your system requirements.
                       style={{marginLeft: 0}}
                       label="z/OSMF Host"
                       variant="standard"
-                      value={localYaml?.zOSMF?.host || installationArgs.zosmfHost || FALLBACK_YAML.zOSMF.host}
+                      value={localYaml?.zOSMF?.host || FALLBACK_YAML.zOSMF.host}
                       onChange={(e) => {
-                        formChangeHandler("zOSMF.host", e.target.value, "zosmfHost");
+                        formChangeHandler("zOSMF.host", e.target.value);
                         if(localYaml){
                           window.electron.ipcRenderer.setConfigByKeyNoValidate('zOSMF.host', e.target.value).then((res: any) => {
                             // console.log('updated zowe.zOSMF.host')
@@ -731,9 +531,9 @@ Please customize the job statement below to match your system requirements.
                       label="z/OSMF Port"
                       variant="standard"
                       type="number"
-                      value={localYaml?.zOSMF?.port || installationArgs.zosmfPort}
+                      value={localYaml?.zOSMF?.port || FALLBACK_YAML.zOSMF.port}
                       onChange={(e) => {
-                        formChangeHandler("zOSMF.port", Number(e.target.value), "zosmfPort");
+                        formChangeHandler("zOSMF.port", Number(e.target.value));
                         if(localYaml){
                           window.electron.ipcRenderer.setConfigByKeyNoValidate('zOSMF.port', Number(e.target.value)).then((res: any) => {
                             // console.log('updated zowe.zOSMF.port')
@@ -754,9 +554,9 @@ Please customize the job statement below to match your system requirements.
                       style={{marginLeft: 0}}
                       label="z/OSMF Application Id"
                       variant="standard"
-                      value={localYaml?.zOSMF?.applId || installationArgs.zosmfApplId}
+                      value={localYaml?.zOSMF?.applId || FALLBACK_YAML.zOSMF.applId}
                       onChange={(e) => {
-                        formChangeHandler("zOSMF.applId", e.target.value, "zosmfApplId");
+                        formChangeHandler("zOSMF.applId", e.target.value);
                         if(localYaml){
                           window.electron.ipcRenderer.setConfigByKeyNoValidate('zOSMF.applId', e.target.value).then((res: any) => {
                             // console.log('updated zowe.zOSMF.applId')
@@ -765,14 +565,13 @@ Please customize the job statement below to match your system requirements.
                       }}
                     />
                     <p style={{ marginTop: '5px', marginBottom: '0', fontSize: 'smaller', color: 'grey' }}>Application ID of your z/OSMF instance.</p>
-
                   </div>
                 </FormControl>
               </div>
             </div>
           )}
           <FormControl sx={{display: 'flex', alignItems: 'center', justifyContent: 'center'}}>
-            <Button sx={{boxShadow: 'none'}} type={step === 1 ? "submit" : "button"} variant="text" onClick={e => validateLocations(e, true)}>Validate locations</Button>
+            <Button sx={{boxShadow: 'none'}} type={step === 1 ? "submit" : "button"} variant="text" onClick={e => validateLocations(e)}>Validate locations</Button>
             {locationsValidated ? <CheckCircle sx={{ color: 'green', fontSize: '1rem' }} /> : validationDetails.error ? null: null}
           </FormControl>
         </Box>


### PR DESCRIPTION
- Get rid of unused vars and multiple logical duplicates like setPlanningStatus, setPlanningState, setNextStepEnabled etc 
All of them were just adding useless lines of code. setNextStepEnabled and setPlanningStatus
Are controlled by setPlanningState which is dependent on jobHeaderSaved and locationsValidated. So these two last variables are controlling everything, there is no need to explicitly set any of above.

- Removed RBAC, Cookie ID, Job ID, job prefix as not relevant to installation, we will add it to the misc config at the end of installation. 

- Remove Editor related code, it was not used as of now but making a mess, I agree that it may be used for displaying large errors, but we can get add it back when implementing a feature.

- Fixed some storage duplications
Example of duplication: setLocationsValidated() sets component state and uses it for rendering, dispatch(setIsLocationValid()) sets redux state but not uses it, instead, it obscurely sets it to the localStorage via setPlanningStageStatus for persistence
This can be fixed by having a selector for isLocationValid in the planning slice and using it instead of component state. 
And it is getting worse when there are too many of these, like in this piece of code:
```
        const formChangeHandler = (key?: string, value?: (string | number), installationArg?: string) => {
          setIsLocationsUpdated(true);
          setPlanningStatus(false);
          setLocationsValidated(false);
          dispatch(setPlanningStatus(false));
          dispatch(setNextStepEnabled(false));
``` 
There is a typo in setPlanningStatus, it should be setPlanningState, but as it is too similar it was never spotted and component state was not updated here, I guess, this lead to adding more explicit setters everywhere, like a snowball.

I didn’t fix all the storage issues as there are more files affected. Like the JobStatement is still stored twice, in electron connection store and in the localStorage StageProgressStatus, that is potential source of issues. And there is still some arguable moment in classification, like what store/slice the job header should belong. Also we still need to remove directories and node/java from installationArgs as it is now stored in yaml. I’ll try to cover this in the next PR with overall storage review. 

- Fixed java and home config setting if found in JAVA_HOME and NODE_HOME

- Added auto config update with z/osmf host = connection host as it is true for most of the use cases.

- Rolled back space check, made it non-interrupting, so it shows the notification but allows to continue

- Removed step 2 as useless on that stage, added green marks for validated fields.

- Probably there are more fixes that I can’t recall now, and It is still far from perfect but I’ve tried to limit the changes in this PR by modifying just one file to make it easier to review and to avoid merge conflicts.  