### PR TITLE
Bug fix for artifactory redirect

### DIFF
--- a/src/actions/PlanningActions.ts
+++ b/src/actions/PlanningActions.ts
@@ -53,7 +53,7 @@ export class PlanningActions {
   
   public static getExampleZowe(): Promise<IResponse> {
     return new Promise((resolve, reject) => {
-      https.get('https://raw.githubusercontent.com/zowe/zowe-install-packaging/v2.x/master/example-zowe.yaml', (res) => {
+      https.get('https://raw.githubusercontent.com/zowe/zowe-install-packaging/v3.x/master/example-zowe.yaml', (res) => {
         let data = '';
 
         res.on('data', (chunk) => {
@@ -77,7 +77,7 @@ export class PlanningActions {
 
   public static getZoweSchema(): Promise<IResponse> {
     return new Promise((resolve, reject) => {
-      https.get('https://raw.githubusercontent.com/zowe/zowe-install-packaging/v2.x/master/schemas/zowe-yaml-schema.json', (res) => {
+      https.get('https://raw.githubusercontent.com/zowe/zowe-install-packaging/v3.x/master/schemas/zowe-yaml-schema.json', (res) => {
         let data = '';
 
         res.on('data', (chunk) => {
@@ -110,7 +110,7 @@ export class PlanningActions {
 
   public static async getZoweVersion(): Promise<IResponse> {
     return new Promise<IResponse>((resolve, reject) => {
-      https.get('https://raw.githubusercontent.com/zowe/zowe-install-packaging/v2.x/master/manifest.json.template', (res) => {
+      https.get('https://raw.githubusercontent.com/zowe/zowe-install-packaging/v3.x/master/manifest.json.template', (res) => {
         let data = '';
   
         res.on('data', (chunk) => {

--- a/src/services/FileTransfer.ts
+++ b/src/services/FileTransfer.ts
@@ -33,12 +33,19 @@ export class FileTransfer {
   return new Promise((resolve, reject) => {
     const saveFile: NodeJS.WritableStream = fs.createWriteStream(fullPath);
     let currentUrl = file;
+    const maxRedirects = 10;
+    let redirectCount = 0;
     const makeRequest = () => {
       https.get(currentUrl, (response: IncomingMessage) => {
         if (response.statusCode === 301 || response.statusCode === 302) {
+          if (redirectCount >= maxRedirects) {
+            reject(new Error(`Max redirect limit reached`));
+            return;
+          }
           const redirectUrl = response.headers.location;
           if (redirectUrl) {
             currentUrl = redirectUrl;
+            redirectCount++;
             makeRequest();
           } else {
             reject(new Error("Redirect URL is missing in the Location header"));
@@ -55,9 +62,11 @@ export class FileTransfer {
         reject(err);
       });
     };
+    
     makeRequest();
   });
 }
+
 
 
   public async upload(config: IIpcConnectionArgs, file: string, fullPath: string, data: DataType = DataType.ASCII) {

--- a/src/services/FileTransfer.ts
+++ b/src/services/FileTransfer.ts
@@ -30,16 +30,35 @@ export class FileTransfer {
   }
 
   public async downloadPax(file: any, fullPath: string): Promise<IResponse> {
-    return new Promise(resolve => {
-      const saveFile: NodeJS.WritableStream = fs.createWriteStream(fullPath);
-      https.get(file, function (response: IncomingMessage) {
-        response.pipe(saveFile);
-        response.on('end', function () {
-          resolve({status: true, details: ''}); 
-        })
-      })
-    })
-  }
+  return new Promise((resolve, reject) => {
+    const saveFile: NodeJS.WritableStream = fs.createWriteStream(fullPath);
+    let currentUrl = file;
+    const makeRequest = () => {
+      https.get(currentUrl, (response: IncomingMessage) => {
+        if (response.statusCode === 301 || response.statusCode === 302) {
+          const redirectUrl = response.headers.location;
+          if (redirectUrl) {
+            currentUrl = redirectUrl;
+            makeRequest();
+          } else {
+            reject(new Error("Redirect URL is missing in the Location header"));
+          }
+        } else if (response.statusCode === 200) {
+          response.pipe(saveFile);
+          response.on('end', function () {
+            resolve({ status: true, details: '' });
+          });
+        } else {
+          reject(new Error(`Failed with status code: ${response.statusCode}`));
+        }
+      }).on('error', (err) => {
+        reject(err);
+      });
+    };
+    makeRequest();
+  });
+}
+
 
   public async upload(config: IIpcConnectionArgs, file: string, fullPath: string, data: DataType = DataType.ASCII) {
     let result;


### PR DESCRIPTION
Artifcatory has moved to a redirect download method and current library does not automatically handle redirects. This pr detects the 3xx respond and redirects to new url. Fixing the bug where convivence build installation fails since it never downloads the Zowe pax. 