### PR TITLE
Add anchor resolution + combinator resolution to fix Zowe 3.3 schema error

### DIFF
--- a/src/renderer/components/common/JsonForms.tsx
+++ b/src/renderer/components/common/JsonForms.tsx
@@ -188,51 +188,56 @@ const makeUISchema = (schema: any, base: string, formData: any): any => {
 }
 
 /* resolveCombinators takes a schema plus the current form data and collapses any oneOf/anyOf it finds. 
-For each combinator, it picks the option that best matches the data (or index 0 as a fallback), 
+For each combinator, it chooses the option that best matches the data (or index 0 as a fallback), 
 then replaces the whole combinator node with that chosen subschema and continues recursively 
 through properties/items/$defs, etc. 
 
 The result is schema without combinators, so JsonForms won’t render tabs as a result of multiple sources */
 const resolveCombinators = (schema: any, data: any): any => {
-  const s = JSON.parse(JSON.stringify(schema));
+  const resolvedSchema = JSON.parse(JSON.stringify(schema));
 
-  const pick = (arr: any[], dataSlice: any) => {
-    // reuse your findMatchingSchemaIndex or default to 0
-    const i = findMatchingSchemaIndex(dataSlice ?? {}, arr);
-    return arr[i] || arr[0];
+  const choose = (schemasArray: any[], formData: any) => {
+    // Find the matching schema for the given form data or default to 0
+    return schemasArray[findMatchingSchemaIndex(formData ?? {}, schemasArray)] || schemasArray[0];
   };
 
-  const traverse = (node: any, dataSlice: any) => {
+  const traverse = (node: any, formData: any) => {
     if (!node || typeof node !== 'object') return;
 
     if (Array.isArray(node.oneOf)) {
-      const chosen = pick(node.oneOf, dataSlice);
+      const chosen = choose(node.oneOf, formData);
       Object.keys(node).forEach(k => delete node[k]);
       Object.assign(node, chosen);
     }
     if (Array.isArray(node.anyOf)) {
-      const chosen = pick(node.anyOf, dataSlice);
+      const chosen = choose(node.anyOf, formData);
       Object.keys(node).forEach(k => delete node[k]);
       Object.assign(node, chosen);
     }
 
-    // descend into typical containers
+    // descend down usual containerized tree
     if (node.properties && typeof node.properties === 'object') {
       for (const [k, v] of Object.entries(node.properties)) {
-        traverse(v, dataSlice?.[k]);
+        traverse(v, formData?.[k]);
       }
     }
     for (const key of ['items','contains','if','then','else','not']) {
-      if (node[key]) traverse(node[key], dataSlice);
+      if (node[key]) {
+        traverse(node[key], formData);
+      }
     }
     for (const key of ['allOf','anyOf','oneOf','prefixItems']) {
-      if (Array.isArray(node[key])) node[key].forEach((x: any) => traverse(x, dataSlice));
+      if (Array.isArray(node[key])) {
+        node[key].forEach((x: any) => traverse(x, formData));
+      }
     }
-    if (node.$defs) Object.values(node.$defs).forEach((x: any) => traverse(x, undefined));
+    if (node.$defs) {
+      Object.values(node.$defs).forEach((x: any) => traverse(x, undefined));
+    }
   };
 
-  traverse(s, data);
-  return s;
+  traverse(resolvedSchema, data);
+  return resolvedSchema;
 }
 
 export default function JsonForm(props: any) {

--- a/src/renderer/components/common/JsonForms.tsx
+++ b/src/renderer/components/common/JsonForms.tsx
@@ -17,6 +17,7 @@ import Radio from '@mui/material/Radio';
 import RadioGroup from '@mui/material/RadioGroup';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import FormControl from '@mui/material/FormControl';
+import { sanitizeOldStyleAnchors } from './Utils';
 
 // Creates a basic input element in the UI schema
 const createControl = (scope: string, label?: string) => ({
@@ -118,6 +119,7 @@ const findMatchingSchemaIndex = (formData: any, oneOfSchemas: any) => {
 };
 
 const makeUISchema = (schema: any, base: string, formData: any): any => {
+  
   if (!schema || !formData) {
     return "";
   }
@@ -185,6 +187,54 @@ const makeUISchema = (schema: any, base: string, formData: any): any => {
   return createVerticalLayout(elements); // Return whole structure
 }
 
+/* resolveCombinators takes a schema plus the current form data and collapses any oneOf/anyOf it finds. 
+For each combinator, it picks the option that best matches the data (or index 0 as a fallback), 
+then replaces the whole combinator node with that chosen subschema and continues recursively 
+through properties/items/$defs, etc. 
+
+The result is schema without combinators, so JsonForms won’t render tabs as a result of multiple sources */
+const resolveCombinators = (schema: any, data: any): any => {
+  const s = JSON.parse(JSON.stringify(schema));
+
+  const pick = (arr: any[], dataSlice: any) => {
+    // reuse your findMatchingSchemaIndex or default to 0
+    const i = findMatchingSchemaIndex(dataSlice ?? {}, arr);
+    return arr[i] || arr[0];
+  };
+
+  const traverse = (node: any, dataSlice: any) => {
+    if (!node || typeof node !== 'object') return;
+
+    if (Array.isArray(node.oneOf)) {
+      const chosen = pick(node.oneOf, dataSlice);
+      Object.keys(node).forEach(k => delete node[k]);
+      Object.assign(node, chosen);
+    }
+    if (Array.isArray(node.anyOf)) {
+      const chosen = pick(node.anyOf, dataSlice);
+      Object.keys(node).forEach(k => delete node[k]);
+      Object.assign(node, chosen);
+    }
+
+    // descend into typical containers
+    if (node.properties && typeof node.properties === 'object') {
+      for (const [k, v] of Object.entries(node.properties)) {
+        traverse(v, dataSlice?.[k]);
+      }
+    }
+    for (const key of ['items','contains','if','then','else','not']) {
+      if (node[key]) traverse(node[key], dataSlice);
+    }
+    for (const key of ['allOf','anyOf','oneOf','prefixItems']) {
+      if (Array.isArray(node[key])) node[key].forEach((x: any) => traverse(x, dataSlice));
+    }
+    if (node.$defs) Object.values(node.$defs).forEach((x: any) => traverse(x, undefined));
+  };
+
+  traverse(s, data);
+  return s;
+}
+
 export default function JsonForm(props: any) {
   let {schema, onChange, formData} = props;
 
@@ -208,6 +258,8 @@ export default function JsonForm(props: any) {
     formData = filterFormData(formData, schema.oneOf[schemaIndex]);
     onChange(formData, schemaIndex);
   }
+
+  const sanitizedSchema = resolveCombinators(sanitizeOldStyleAnchors(requiredSchema), formData);
 
   return (
     <ThemeProvider theme={jsonFormTheme}>
@@ -234,8 +286,8 @@ export default function JsonForm(props: any) {
 
       }
       <JsonForms
-        schema={requiredSchema}
-        uischema={makeUISchema(requiredSchema, '/', formData)}
+        schema={sanitizedSchema}
+        uischema={makeUISchema(sanitizedSchema, '/', formData)}
         data={formData}
         renderers={materialRenderers}
         cells={materialCells}

--- a/src/renderer/components/common/Stepper.tsx
+++ b/src/renderer/components/common/Stepper.tsx
@@ -347,6 +347,7 @@ export default function HorizontalLinearStepper({stages, initialization}:{stages
               </Button>
             }
             {stages[activeStep] && stages[activeStep].isSkippable &&
+            !skipButtonDisabled(stages, activeStep, activeSubStep) && (
               <Button 
                 disabled={skipButtonDisabled(stages, activeStep, activeSubStep)}
                 variant="contained" 
@@ -355,7 +356,7 @@ export default function HorizontalLinearStepper({stages, initialization}:{stages
               >
                 Skip {stages[activeStep] && stages[activeStep].subStages ? stages[activeStep].subStages[activeSubStep].label : stages[activeStep]? stages[activeStep].label: ''}
               </Button>
-            }
+            )}
             {stages[activeStep] && stages[activeStep].nextButton &&
               <Button 
               disabled={!isNextStepEnabled}

--- a/src/renderer/components/common/Utils.tsx
+++ b/src/renderer/components/common/Utils.tsx
@@ -2354,22 +2354,27 @@ and removes duplicate $anchors under the same base $id. It only touches anchors 
 So Ajv won’t throw the “reference resolves to more than one schema” error when trying to merge old-style & new style Zowe schema */
 export function sanitizeOldStyleAnchors(schema: any) {
   const root = JSON.parse(JSON.stringify(schema));
-  const seen: Set<string> = new Set(); // track anchors by absolute "baseId#anchor"
+  const traversedAnchors: Set<string> = new Set(); // track anchors by absolute "baseId#anchor"
   const traverse = (node: any, baseId: string) => {
-    if (!node || typeof node !== 'object') return;
+    if (!node || typeof node !== 'object')  { return; }
 
     // normalize old-style `"$id":"#name"` -> `$anchor`
     if (typeof node.$id === 'string' && node.$id.startsWith('#')) {
       const frag = node.$id.slice(1);
-      if (frag && !node.$anchor) node.$anchor = frag;
+      if (frag && !node.$anchor) { 
+        node.$anchor = frag; 
+      }
       delete node.$id;
     }
-    if (typeof node.$id === 'string' && node.$id && !node.$id.startsWith('#')) baseId = node.$id;
-
+    if (typeof node.$id === 'string' && node.$id && !node.$id.startsWith('#')) {
+      baseId = node.$id;
+    }
     if (typeof node.$anchor === 'string' && node.$anchor) {
       const key = `${baseId}#${node.$anchor}`;
-      if (seen.has(key)) delete node.$anchor;
-      else seen.add(key);
+      if (traversedAnchors.has(key)) {
+        delete node.$anchor;
+      }
+      else traversedAnchors.add(key);
     }
 
     const keys = [

--- a/src/renderer/components/common/Utils.tsx
+++ b/src/renderer/components/common/Utils.tsx
@@ -2345,3 +2345,48 @@ export const FALLBACK_YAML = {
     }
   }
 }
+
+/* sanitizeOldStyleAnchors deep-clones, then recursively traverses the JSON Schema tree
+Starting at root node, it converts legacy fragment "$id": "#name" into "$anchor": "name", 
+tracks the current base $id as it descends (calls itself on each child schema (properties, items, oneOf, etc.)), 
+and removes duplicate $anchors under the same base $id. It only touches anchors (and that legacy $id form), leaving $refs and everything else intact
+
+So Ajv won’t throw the “reference resolves to more than one schema” error when trying to merge old-style & new style Zowe schema */
+export function sanitizeOldStyleAnchors(schema: any) {
+  const root = JSON.parse(JSON.stringify(schema));
+  const seen: Set<string> = new Set(); // track anchors by absolute "baseId#anchor"
+  const traverse = (node: any, baseId: string) => {
+    if (!node || typeof node !== 'object') return;
+
+    // normalize old-style `"$id":"#name"` -> `$anchor`
+    if (typeof node.$id === 'string' && node.$id.startsWith('#')) {
+      const frag = node.$id.slice(1);
+      if (frag && !node.$anchor) node.$anchor = frag;
+      delete node.$id;
+    }
+    if (typeof node.$id === 'string' && node.$id && !node.$id.startsWith('#')) baseId = node.$id;
+
+    if (typeof node.$anchor === 'string' && node.$anchor) {
+      const key = `${baseId}#${node.$anchor}`;
+      if (seen.has(key)) delete node.$anchor;
+      else seen.add(key);
+    }
+
+    const keys = [
+      'properties','patternProperties','$defs','definitions',
+      'items','prefixItems','contains','if','then','else','not','allOf','anyOf','oneOf','additionalProperties'
+    ];
+    for (const k of keys) {
+      const ch = node[k];
+      if (!ch) continue;
+      if (Array.isArray(ch)) ch.forEach(c => traverse(c, baseId));
+      else if (typeof ch === 'object') {
+        if (k === 'properties' || k === 'patternProperties' || k === '$defs' || k === 'definitions') {
+          Object.values(ch).forEach((c: any) => traverse(c, baseId));
+        } else traverse(ch, baseId);
+      }
+    }
+  };
+  traverse(root, root.$id || '');
+  return root;
+}

--- a/src/renderer/components/stages/CachingService.tsx
+++ b/src/renderer/components/stages/CachingService.tsx
@@ -27,7 +27,7 @@ import { getStageDetails, getSubStageDetails } from "../../../services/StageDeta
 import { getProgress, setVsamInitState, updateSubStepSkipStatus, getInstallationArguments, getVsamInitState, isInitializationStageComplete, getZoweMajorVersion } from "./progress/StageProgressStatus";
 import { InitSubStepsState } from "../../../types/stateInterfaces";
 import { alertEmitter } from "../Header";
-import { DEF_ZOWE_MAJOR_VERS, INIT_STAGE_LABEL, ajv } from "../common/Utils";
+import { sanitizeOldStyleAnchors, DEF_ZOWE_MAJOR_VERS, INIT_STAGE_LABEL, ajv } from "../common/Utils";
 
 const CachingService = () => {
 
@@ -70,7 +70,7 @@ const CachingService = () => {
 
   const [defaultErrorMessage] = useState("Please ensure that the volume, storage class & dataset values are accurate.");
 
-  const [validate] = useState(() => ajv.getSchema("https://zowe.org/schemas/v3/server-base") || ajv.compile(setupSchema))
+  const [validate] = useState(() => ajv.getSchema("https://zowe.org/schemas/v3/server-base") || ajv.compile(sanitizeOldStyleAnchors(setupSchema)));
 
   useEffect(() => {
     stageStatusRef.current = stageStatus;

--- a/src/renderer/components/stages/Certificates.tsx
+++ b/src/renderer/components/stages/Certificates.tsx
@@ -26,7 +26,7 @@ import { setActiveStep } from "./progress/activeStepSlice";
 import { getStageDetails, getSubStageDetails } from "../../../services/StageDetails";
 import { getProgress, setCertificateInitState, getCertificateInitState, updateSubStepSkipStatus, getInstallationArguments, isInitializationStageComplete } from "./progress/StageProgressStatus";
 import { CertInitSubStepsState } from "../../../types/stateInterfaces";
-import { TYPE_YAML, TYPE_OUTPUT, INIT_STAGE_LABEL, CERTIFICATES_STAGE_LABEL, ajv, deepMerge } from "../common/Utils";
+import { sanitizeOldStyleAnchors, TYPE_YAML, TYPE_OUTPUT, INIT_STAGE_LABEL, CERTIFICATES_STAGE_LABEL, ajv, deepMerge } from "../common/Utils";
 
 const Certificates = () => {
 
@@ -59,7 +59,7 @@ const Certificates = () => {
 
   let timer: any;
 
-  const [validate] = useState(() => ajv.getSchema("https://zowe.org/schemas/v3/server-base") || ajv.compile(setupSchema))
+  const [validate] = useState(() => ajv.getSchema("https://zowe.org/schemas/v3/server-base") || ajv.compile(sanitizeOldStyleAnchors(setupSchema)));
 
   useEffect(() => {
     stageStatusRef.current = stageStatus;

--- a/src/renderer/components/stages/Security.tsx
+++ b/src/renderer/components/stages/Security.tsx
@@ -26,7 +26,7 @@ import { setActiveStep } from "./progress/activeStepSlice";
 import { getStageDetails, getSubStageDetails } from "../../../services/StageDetails";
 import { setProgress, getProgress, setSecurityInitState, getSecurityInitState, updateSubStepSkipStatus, getInstallationArguments, isInitializationStageComplete } from "./progress/StageProgressStatus";
 import { InitSubStepsState } from "../../../types/stateInterfaces";
-import { JCL_UNIX_SCRIPT_OK, INIT_STAGE_LABEL, SECURITY_STAGE_LABEL, ajv, SERVER_COMMON } from '../common/Utils';
+import { sanitizeOldStyleAnchors, JCL_UNIX_SCRIPT_OK, INIT_STAGE_LABEL, SECURITY_STAGE_LABEL, ajv, SERVER_COMMON } from '../common/Utils';
 import { alertEmitter } from "../Header";
 
 const Security = () => {
@@ -60,7 +60,7 @@ const Security = () => {
   const [connectionArgs] = useState(useAppSelector(selectConnectionArgs));
 
   let timer: any;
-  const [validate] = useState(() => ajv.getSchema("https://zowe.org/schemas/v3/server-base") || ajv.compile(setupSchema));
+  const [validate] = useState(() => ajv.getSchema("https://zowe.org/schemas/v3/server-base") || ajv.compile(sanitizeOldStyleAnchors(setupSchema)));
 
   useEffect(() => {
     stageStatusRef.current = stageStatus;

--- a/src/renderer/components/stages/installation/Installation.tsx
+++ b/src/renderer/components/stages/installation/Installation.tsx
@@ -24,7 +24,7 @@ import { alertEmitter } from "../../Header";
 import { createTheme } from '@mui/material/styles';
 import {stages} from "../../configuration-wizard/Wizard";
 import { setActiveStep } from "../progress/activeStepSlice";
-import { TYPE_YAML, TYPE_OUTPUT, JCL_UNIX_SCRIPT_OK, FALLBACK_YAML, ajv, INIT_STAGE_LABEL, INSTALL_STAGE_LABEL} from '../../common/Utils';
+import { sanitizeOldStyleAnchors, TYPE_YAML, TYPE_OUTPUT, JCL_UNIX_SCRIPT_OK, FALLBACK_YAML, ajv, INIT_STAGE_LABEL, INSTALL_STAGE_LABEL} from '../../common/Utils';
 import { getStageDetails, getSubStageDetails } from "../../../../services/StageDetails"; 
 import { getProgress, setDatasetInstallationState, getDatasetInstallationState, getInstallationTypeStatus, updateSubStepSkipStatus, getInstallationArguments, datasetInstallationStatus, isInitializationStageComplete } from "../progress/StageProgressStatus";
 import { DatasetInstallationState } from "../../../../types/stateInterfaces";
@@ -66,7 +66,7 @@ const Installation = () => {
   let timer: any;
   const [installationType] = useState(getInstallationTypeStatus().installationType);
 
-  const [validate] = useState(() => ajv.getSchema("https://zowe.org/schemas/v3/server-base") || ajv.compile(setupSchema));
+  const [validate] = useState(() => ajv.getSchema("https://zowe.org/schemas/v3/server-base") || ajv.compile(sanitizeOldStyleAnchors(setupSchema)));
 
   useEffect(() => {
     stageStatusRef.current = stageStatus;


### PR DESCRIPTION
My 1 new sanitizer method successfully fixes both schema compile issues (1 in JsonForms component, 1 in our own AJV compile elsewhere ), introduced in Zowe V3.3. It is unclear if schema error is with Zowe versus Wizard's internal mishandling of old style & new style schema consolidation. You'll likely encounter it 1st on Installation stage, after upload step.

> ERROR
reference "#zoweDataset" resolves to more than one schema     at ambiguos (webpack-internal:///./node_modules/ajv/dist/compile/resolve.js:151:16)     at Ajv2019.addRef (webpack-internal:///./node_modules/ajv/dist/compile/resolve.js:118:23)     at Ajv2019.addAnchor (webpack-internal:///./node_modules/ajv/dist/compile/resolve.js:141:24)     at eval (webpack-internal:///./node_modules/ajv/dist/compile/resolve.js:110:19)     at _traverse (webpack-internal:///./node_modules/json-schema-traverse/index.js:69:5)     at _traverse (webpack-internal:///./node_modules/json-schema-traverse/index.js:75:13)     at _traverse (webpack-internal:///./node_modules/json-schema-traverse/index.js:80:13)     at module.exports (webp0ack-internal:///./node_modules/json-schema-traverse/index.js:14:3)     at Ajv2019.getSchemaRefs (webpack-internal:///./node_modules/ajv/dist/compile/resolve.js:103:5)     at Ajv2019._addSchema (webpack-internal:///./node_modules/ajv/dist/core.js:451:51)

 
<img width="1059" height="806" alt="image" src="https://github.com/user-attachments/assets/9fd52749-883a-4920-936e-b7262c22f787" />
 
But, fixed. Problem is, the new schema that becomes successfully compiled is not correctly readable by the UI partially due to our custom methods. I now have resolve combinators method that takes into account Sakshi's existing code and pre-resolve combinators in the schema so JsonForms never sees oneOf/anyOf and doesnt duplicate tabs like in 1st screenshot

<img width="1082" height="660" alt="image" src="https://github.com/user-attachments/assets/34c5f232-9f23-4086-abdc-b483c2d4f64e" />


